### PR TITLE
Bugfix server backups

### DIFF
--- a/BFBMX.Desktop/App.xaml.cs
+++ b/BFBMX.Desktop/App.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using BFBMX.Desktop.Collections;
 using BFBMX.Desktop.Helpers;
+using BFBMX.Service.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -50,6 +51,7 @@ namespace BFBMX.Desktop
             string targetUrl = DesktopEnvFactory.GetServerHostnameAndPort();
             services.AddSingleton(new ApiClientSettings(targetUrl));
             services.AddSingleton<IApiClient, ApiClient>();
+            services.AddSingleton<IFileProcessor, FileProcessor>();
             services.AddSingleton<IDiscoveredFilesCollection, DiscoveredFilesCollection>();
 
             // inject viewmodels here as transient services

--- a/BFBMX.Desktop/App.xaml.cs
+++ b/BFBMX.Desktop/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Windows;
+using BFBMX.Desktop.Collections;
 using BFBMX.Desktop.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -40,19 +41,17 @@ namespace BFBMX.Desktop
             services.Configure<DesktopLoggerConfiguration>(config =>
             {
                 config.EventId = 0;
-                // override LogLevelToTextOutputMap configuration if wanted
-                //string baseProfilePath = Environment.GetEnvironmentVariable("USERPROFILE") ?? @"C:\";
-                //string basePath = baseProfilePath == @"C:\" ? baseProfilePath : Path.Combine(baseProfilePath, "Documents");
-                //string? envLogPath = Environment.GetEnvironmentVariable("BFBMX_FOLDER_NAME");
-                //string logPath = string.IsNullOrEmpty(envLogPath) ? "BFBMX" : envLogPath;
-                //string logfileName = "bfbmx-desktop.log";
                 config.LogfilePath = Path.Combine(DesktopEnvFactory.GetBfBmxLogPath(), DesktopEnvFactory.GetBfBmxLogFileName()); //(basePath, logPath, logfileName);
             });
             // add custom logging provider to the IoC container/collection
             services.AddSingleton<ILoggerProvider, DesktopLoggerProvider>();
 
-            // inject services here e.g. services.addsingleton<TInterface, TImplementation>();
-            
+            // inject services here e.g. services.AddSingleton<TInterface, TImplementation>() etc
+            string targetUrl = DesktopEnvFactory.GetServerHostnameAndPort();
+            services.AddSingleton(new ApiClientSettings(targetUrl));
+            services.AddSingleton<IApiClient, ApiClient>();
+            services.AddSingleton<IDiscoveredFilesCollection, DiscoveredFilesCollection>();
+
             // inject viewmodels here as transient services
             services.AddTransient<ViewModels.MainWindowViewModel>();
 

--- a/BFBMX.Desktop/Collections/DiscoveredFilesCollection.cs
+++ b/BFBMX.Desktop/Collections/DiscoveredFilesCollection.cs
@@ -21,30 +21,39 @@ namespace BFBMX.Desktop.Collections
     {
         private readonly IApiClient _apiClient;
         private readonly ILogger<DiscoveredFilesCollection> _logger;
+        private readonly IFileProcessor _fileProcessor;
 
         public int MaxItems { get; } = 6;
 
-        public DiscoveredFilesCollection(ILogger<DiscoveredFilesCollection> logger,
-            IApiClient apiClient)
+        public DiscoveredFilesCollection(
+            ILogger<DiscoveredFilesCollection> logger,
+            IApiClient apiClient,
+            IFileProcessor fileProcessor)
         {
             _apiClient = apiClient;
             _logger = logger;
+            _fileProcessor = fileProcessor;
         }
 
         public async Task EnqueueAsync(DiscoveredFileModel item)
         {
+            if( this.Any(x => x.FullFilePath == item.FullFilePath))
+            {
+                _logger.LogWarning("DiscoveredFilesCollection EnqueueAsync: File {filepath} is a DUPLICATE. Storing in memory but contents might not get added to database.", item.FullFilePath);
+            }
+
             Enqueue(item);
-            WinlinkMessageModel winlinkMessage = FileProcessor.ProcessWinlinkMessageFile(item.FileTimeStamp, Environment.MachineName, item.FullFilePath);
+            WinlinkMessageModel winlinkMessage = _fileProcessor.ProcessWinlinkMessageFile(item.FileTimeStamp, Environment.MachineName, item.FullFilePath);
+
             if (winlinkMessage is not null && winlinkMessage.BibRecords.Count > 0)
             {
-                // todo: address these hanging, unused, promised variables
-                bool wroteToFile = await FileProcessor.WriteWinlinkMessageToFile(winlinkMessage, Path.Combine(DesktopEnvFactory.GetBfBmxLogPath(), DesktopEnvFactory.GetBibRecordsLogFileName()));
+                bool wroteToFile = _fileProcessor.WriteWinlinkMessageToFile(winlinkMessage, Path.Combine(DesktopEnvFactory.GetBfBmxLogPath(), DesktopEnvFactory.GetBibRecordsLogFileName()));
                 bool postedToApi = await _apiClient.PostWinlinkMessageAsync(winlinkMessage.ToJsonString());
-                _logger.LogInformation("DiscoveredFilesCollection: EnqueueAync: MaxItems: {maxitems}. Item count: {count}.", MaxItems, Count);
+                _logger.LogInformation("DiscoveredFilesCollection EnqueueAync: Wrote to file? {wroteToFile}. Posted to API? {postedToApi}. Items in collection: {collectionCount}.", wroteToFile, postedToApi, Count);
             }
             else
             {
-                _logger.LogInformation("DiscoveredFilesCollection: EnqueueAsync: No bibrecords found in winlinkMessage.");
+                _logger.LogInformation("DiscoveredFilesCollection EnqueueAsync: No bibrecords found in winlinkMessage.");
             }
         }
     }

--- a/BFBMX.Desktop/Collections/DiscoveredFilesCollection.cs
+++ b/BFBMX.Desktop/Collections/DiscoveredFilesCollection.cs
@@ -37,7 +37,14 @@ namespace BFBMX.Desktop.Collections
 
         public async Task EnqueueAsync(DiscoveredFileModel item)
         {
-            if( this.Any(x => x.FullFilePath == item.FullFilePath))
+            if (item is null)
+            {
+                _logger.LogWarning("DiscoveredFileCollection EnqueueAsync: Item is null, ignoring.");
+                return;
+            }
+
+            // todo: find out from stakeholders if full path duplicates are allowed
+            if( this.Contains(item))
             {
                 _logger.LogWarning("DiscoveredFilesCollection EnqueueAsync: File {filepath} is a DUPLICATE. Storing in memory but contents might not get added to database.", item.FullFilePath);
             }

--- a/BFBMX.Desktop/Helpers/ApiClient.cs
+++ b/BFBMX.Desktop/Helpers/ApiClient.cs
@@ -53,37 +53,37 @@ namespace BFBMX.Desktop.Helpers
                 }
                 catch (UriFormatException uriFormEx)
                 {
-                    _logger.LogError("Forming Uri failed\nStacktrace: {stacktrace}\nMessage: {msg}", uriFormEx.StackTrace, uriFormEx.Message);
+                    _logger.LogError("Forming Uri failed\nStacktrace: {uriFormatExceptionTrace}\nMessage: {uriFormatExceptionMessage}", uriFormEx.StackTrace, uriFormEx.Message);
                 }
                 catch (FormatException frmtEx)
                 {
-                    _logger.LogError("Forming a valid URI failed!\nStacktrace: {stacktrace}\nMessage: {msg}", frmtEx.StackTrace, frmtEx.Message);
+                    _logger.LogError("Forming a valid URI failed!\nStacktrace: {formatExceptionTrace}\nMessage: {formatExceptionMessage}", frmtEx.StackTrace, frmtEx.Message);
                     result = false;
                 }
                 catch (ArgumentNullException ArgNullEx)
                 {
-                    _logger.LogError("PostWinlinkMessageAsync: Argument Null Exception Stacktrace: {argnullst}. Message: {argnullmsg}", ArgNullEx.StackTrace, ArgNullEx.Message);
+                    _logger.LogError("PostWinlinkMessageAsync: Argument Null Exception Stacktrace: {argumentNullExceptionTrace}. Message: {argumentNullExceptionMessage}", ArgNullEx.StackTrace, ArgNullEx.Message);
                     if (ArgNullEx.InnerException != null)
                     {
-                        _logger.LogError("PostWinlinkMessageAsync: Arugment Null Inner Exception {argnullexinnermsg}", ArgNullEx.InnerException.Message);
+                        _logger.LogError("PostWinlinkMessageAsync: Arugment Null Inner Exception {innerExceptionMessage}", ArgNullEx.InnerException.Message);
                     }
                     result = false;
                 }
                 catch (HttpRequestException HReqEx)
                 {
-                    _logger.LogError("PostWinlinkMessageAsync: HTTP Request Exception Stacktrace: {argnullst}. Message: {argnullmsg}", HReqEx.StackTrace, HReqEx.Message);
+                    _logger.LogError("PostWinlinkMessageAsync: HTTP Request Exception Stacktrace: {httpRequestExceptionTrace}. Message: {httpRequestExceptionMessage}", HReqEx.StackTrace, HReqEx.Message);
                     if (HReqEx.InnerException != null)
                     {
-                        _logger.LogError("PostWinlinkMessageAsync: HTTP Request Inner Exception {argnullexinnermsg}", HReqEx.InnerException.Message);
+                        _logger.LogError("PostWinlinkMessageAsync: HTTP Request Inner Exception {innerExceptionMessage}", HReqEx.InnerException.Message);
                     }
                     result = false;
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError("PostWinlinkMessageAsync: Exception Stacktrace: {argnullst}. Message: {argnullmsg}", ex.StackTrace, ex.Message);
+                    _logger.LogError("PostWinlinkMessageAsync: Exception Stacktrace: {exceptionTrace}. Message: {exceptionMessage}", ex.StackTrace, ex.Message);
                     if (ex.InnerException != null)
                     {
-                        _logger.LogError("PostWinlinkMessageAsync: Exception Inner Exception {argnullexinnermsg}", ex.InnerException.Message);
+                        _logger.LogError("PostWinlinkMessageAsync: Exception Inner Exception {innerExceptionMessage}", ex.InnerException.Message);
                     }
                     result = false;
                 }

--- a/BFBMX.Desktop/Helpers/ApiClient.cs
+++ b/BFBMX.Desktop/Helpers/ApiClient.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace BFBMX.Desktop.Helpers
+{
+    public class ApiClient : HttpClient, IApiClient
+    {
+        private HttpClient _apiClient;
+        private readonly ApiClientSettings _apiClientSettings;
+        private readonly ILogger<ApiClient> _logger;
+
+        public ApiClient(ILogger<ApiClient> logger, ApiClientSettings apiConfig)
+        {
+            _logger = logger;
+            _apiClient = new HttpClient();
+            _apiClientSettings = apiConfig;
+            _apiClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        }
+
+        public async Task<bool> PostWinlinkMessageAsync(string jsonPayload)
+        {
+            string postWinlinkMsgUri = "WinlinkMessage"; // post Winlink Message service endpoint
+            bool result = false;
+            if (string.IsNullOrWhiteSpace(jsonPayload))
+            {
+                _logger.LogWarning("PostWinlinkMessageAsync: The JSON payload is empty or null. NOT calling server.");
+                return result;
+            }
+            else
+            {
+                StringContent postPayload = new(jsonPayload, Encoding.UTF8, "application/json");
+                try
+                {
+                    string uriPath = System.IO.Path.Combine(_apiClientSettings.BaseUri, postWinlinkMsgUri);
+                    _logger.LogInformation("ApiClient set uriPath to {uriPath}.", uriPath);
+
+                    // httpclient will dispose automatically to conserve resources
+                    using (HttpResponseMessage response = await _apiClient.PostAsync(uriPath, postPayload))
+                    {
+                        if (response.IsSuccessStatusCode)
+                        {
+                            result = true;
+                            _logger.LogInformation("PostWinlinkMessageAsync: Response was success status code.");
+                        }
+                        else
+                        {
+                            _logger.LogWarning("PostWinlinkMessageAsync: Response was not a success status code.");
+                            result = false;
+                        }
+                    }
+                }
+                catch (UriFormatException uriFormEx)
+                {
+                    _logger.LogError("Forming Uri failed\nStacktrace: {stacktrace}\nMessage: {msg}", uriFormEx.StackTrace, uriFormEx.Message);
+                }
+                catch (FormatException frmtEx)
+                {
+                    _logger.LogError("Forming a valid URI failed!\nStacktrace: {stacktrace}\nMessage: {msg}", frmtEx.StackTrace, frmtEx.Message);
+                    result = false;
+                }
+                catch (ArgumentNullException ArgNullEx)
+                {
+                    _logger.LogError("PostWinlinkMessageAsync: Argument Null Exception Stacktrace: {argnullst}. Message: {argnullmsg}", ArgNullEx.StackTrace, ArgNullEx.Message);
+                    if (ArgNullEx.InnerException != null)
+                    {
+                        _logger.LogError("PostWinlinkMessageAsync: Arugment Null Inner Exception {argnullexinnermsg}", ArgNullEx.InnerException.Message);
+                    }
+                    result = false;
+                }
+                catch (HttpRequestException HReqEx)
+                {
+                    _logger.LogError("PostWinlinkMessageAsync: HTTP Request Exception Stacktrace: {argnullst}. Message: {argnullmsg}", HReqEx.StackTrace, HReqEx.Message);
+                    if (HReqEx.InnerException != null)
+                    {
+                        _logger.LogError("PostWinlinkMessageAsync: HTTP Request Inner Exception {argnullexinnermsg}", HReqEx.InnerException.Message);
+                    }
+                    result = false;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError("PostWinlinkMessageAsync: Exception Stacktrace: {argnullst}. Message: {argnullmsg}", ex.StackTrace, ex.Message);
+                    if (ex.InnerException != null)
+                    {
+                        _logger.LogError("PostWinlinkMessageAsync: Exception Inner Exception {argnullexinnermsg}", ex.InnerException.Message);
+                    }
+                    result = false;
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/BFBMX.Desktop/Helpers/ApiClientSettings.cs
+++ b/BFBMX.Desktop/Helpers/ApiClientSettings.cs
@@ -1,0 +1,15 @@
+﻿namespace BFBMX.Desktop.Helpers
+{
+    public class ApiClientSettings : IApiClientSettings
+    {
+        private readonly string _baseUri;
+
+        public string BaseUri => _baseUri;
+
+        public ApiClientSettings(string serverNameAndPort)
+        {
+            // see https://stackoverflow.com/questions/70628314/injecting-primitive-type-in-constructor-of-generic-type-using-microsoft-di
+            _baseUri = serverNameAndPort ?? throw new ArgumentNullException();
+        }
+    }
+}

--- a/BFBMX.Desktop/Helpers/DesktopEnvFactory.cs
+++ b/BFBMX.Desktop/Helpers/DesktopEnvFactory.cs
@@ -30,13 +30,13 @@
         /// <returns>Filename for storing plain text running log data.</returns>
         public static string GetBfBmxLogFileName()
         {
-            string logFilename = "bfbmx-desktop.log";
+            string logFilename = "bfbmx-desktop-app-log.txt";
             return logFilename;
         }
 
         public static string GetBibRecordsLogFileName()
         {
-            string logFilename = "BibRecordsLog.txt";
+            string logFilename = "captured-bib-records.txt";
             return logFilename;
         }
 
@@ -48,19 +48,18 @@
 
             string serverName = Environment.GetEnvironmentVariable("BFBMX_SERVERNAME") ?? DEFAULTSERVER;
             string envVarPort = Environment.GetEnvironmentVariable("BFBMX_SERVERPORT") ?? string.Empty;
-            int tempPort;
 
             // if parse fails tempPort will be set to DEFAULTPORT
-            if (int.TryParse(envVarPort, out tempPort))
+            if (int.TryParse(envVarPort, out int tempPort))
             {
                 // tempPort is set correctly when TryParse succeeds
             }
             else
-            { 
+            {
                 tempPort = DEFAULTPORT;
             }
 
-            return $"{PROTOCOL}{serverName}:{tempPort.ToString()}/";
+            return $"{PROTOCOL}{serverName}:{tempPort}/";
         }
     }
 }

--- a/BFBMX.Desktop/Helpers/DesktopEnvFactory.cs
+++ b/BFBMX.Desktop/Helpers/DesktopEnvFactory.cs
@@ -1,6 +1,5 @@
 ﻿namespace BFBMX.Desktop.Helpers
 {
-    // todo: make DesktopEnvFactory class static
     public static class DesktopEnvFactory
     {
         public static string GetUserProfilePath()
@@ -39,6 +38,29 @@
         {
             string logFilename = "BibRecordsLog.txt";
             return logFilename;
+        }
+
+        public static string GetServerHostnameAndPort()
+        {
+            const string PROTOCOL = @"http://";
+            const string DEFAULTSERVER = "localhost";
+            const int DEFAULTPORT = 5150;
+
+            string serverName = Environment.GetEnvironmentVariable("BFBMX_SERVERNAME") ?? DEFAULTSERVER;
+            string envVarPort = Environment.GetEnvironmentVariable("BFBMX_SERVERPORT") ?? string.Empty;
+            int tempPort;
+
+            // if parse fails tempPort will be set to DEFAULTPORT
+            if (int.TryParse(envVarPort, out tempPort))
+            {
+                // tempPort is set correctly when TryParse succeeds
+            }
+            else
+            { 
+                tempPort = DEFAULTPORT;
+            }
+
+            return $"{PROTOCOL}{serverName}:{tempPort.ToString()}/";
         }
     }
 }

--- a/BFBMX.Desktop/Helpers/IApiClient.cs
+++ b/BFBMX.Desktop/Helpers/IApiClient.cs
@@ -1,0 +1,8 @@
+﻿
+namespace BFBMX.Desktop.Helpers
+{
+    public interface IApiClient
+    {
+        Task<bool> PostWinlinkMessageAsync(string jsonPayload);
+    }
+}

--- a/BFBMX.Desktop/Helpers/IApiClientSettings.cs
+++ b/BFBMX.Desktop/Helpers/IApiClientSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace BFBMX.Desktop.Helpers
+{
+    public interface IApiClientSettings
+    {
+        string BaseUri { get; }
+    }
+}

--- a/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
@@ -16,9 +16,11 @@ namespace BFBMX.Desktop.ViewModels
 
         private readonly ILogger<MainWindowViewModel> _logger;
 
-        public MainWindowViewModel(ILogger<MainWindowViewModel> logger)
+        public MainWindowViewModel(ILogger<MainWindowViewModel> logger,
+            IDiscoveredFilesCollection discoveredFilesCollection)
         {
             _logger = logger;
+            _discoveredFiles = discoveredFilesCollection;
         }
 
         [ObservableProperty]
@@ -29,7 +31,7 @@ namespace BFBMX.Desktop.ViewModels
         public string? _charlieStatusMessage = "Monitor #3 is in development.";
 
         [ObservableProperty]
-        public DiscoveredFilesCollection? _discoveredFiles = new();
+        public IDiscoveredFilesCollection _discoveredFiles;
 
         /***** Global Monitor Functions *****/
         public async void HandleFileCreatedAsync(object sender, FileSystemEventArgs e)
@@ -38,7 +40,7 @@ namespace BFBMX.Desktop.ViewModels
             string? discoveredFilepath = e.FullPath ?? "unknown - check logs!";
             // put the discovered filepath info into the queue and be done
             DiscoveredFileModel newFile = new(discoveredFilepath);
-            DiscoveredFiles!.Enqueue(newFile);
+            await _discoveredFiles.EnqueueAsync(newFile);
             _logger.LogInformation("Enqueued path {discoveredFilepath}", discoveredFilepath);
         }
 

--- a/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
@@ -40,7 +40,7 @@ namespace BFBMX.Desktop.ViewModels
             string? discoveredFilepath = e.FullPath ?? "unknown - check logs!";
             // put the discovered filepath info into the queue and be done
             DiscoveredFileModel newFile = new(discoveredFilepath);
-            await _discoveredFiles.EnqueueAsync(newFile);
+            await DiscoveredFiles.EnqueueAsync(newFile);
             _logger.LogInformation("Enqueued path {discoveredFilepath}", discoveredFilepath);
         }
 

--- a/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
@@ -38,10 +38,11 @@ namespace BFBMX.Desktop.ViewModels
         {
             _logger.LogInformation("HandleFileCreatedAsync called.");
             string? discoveredFilepath = e.FullPath ?? "unknown - check logs!";
-            // put the discovered filepath info into the queue and be done
             DiscoveredFileModel newFile = new(discoveredFilepath);
             await DiscoveredFiles.EnqueueAsync(newFile);
             _logger.LogInformation("Enqueued path {discoveredFilepath}", discoveredFilepath);
+            // todo: implement a collection for displaying latest data and send discovered files to it here
+
         }
 
         public void HandleError(object sender, ErrorEventArgs e)

--- a/BFBMX.ServerApi/Collections/BibReportsCollection.cs
+++ b/BFBMX.ServerApi/Collections/BibReportsCollection.cs
@@ -8,20 +8,25 @@ namespace BFBMX.ServerApi.Collections;
 
 public class BibReportsCollection : ObservableCollection<WinlinkMessageModel>, IBibReportsCollection
 {
+    private static Object LockObject = new Object();
     private readonly IDbContextFactory<BibMessageContext> _dbContextFactory;
     private readonly ILogger<BibReportsCollection> _logger;
+    private readonly IDataExImService _dataExImService;
 
     public BibReportsCollection(
         IDbContextFactory<BibMessageContext> dbContextFactory,
-        ILogger<BibReportsCollection> logger)
+        ILogger<BibReportsCollection> logger,
+        IDataExImService dataExImService
+        )
     {
         _dbContextFactory = dbContextFactory;
         _logger = logger;
+        _dataExImService = dataExImService;
     }
 
     public bool AddEntityToCollection(WinlinkMessageModel wlMessagePayload)
     {
-        int saveCount = 0;
+        int savedEntityCount = 0;
 
         if (wlMessagePayload is null)
         {
@@ -30,17 +35,27 @@ public class BibReportsCollection : ObservableCollection<WinlinkMessageModel>, I
         }
         else
         {
+            string wlMsgId = string.IsNullOrWhiteSpace(wlMessagePayload.WinlinkMessageId) ? "ERROR!" : wlMessagePayload.WinlinkMessageId;
+
+            lock(LockObject)
+            {
+                Add(wlMessagePayload);
+            }
+
+            _logger.LogInformation("Stored message ID {msgid} to the internal collection.", wlMsgId);
+
             try
             {
                 // see https://learn.microsoft.com/en-us/ef/core/dbcontext-configuration/#using-a-dbcontext-factory-eg-for-blazor
                 using (var bibMessageContext = _dbContextFactory.CreateDbContext())
                 {
                     bibMessageContext.Add(wlMessagePayload);
-                    saveCount = bibMessageContext.SaveChanges();
-                    Add(wlMessagePayload);
-                    _logger.LogInformation("Stored {num} messages to the internal DB.", saveCount);
+                    savedEntityCount = bibMessageContext.SaveChanges();
+                    int bibCount = savedEntityCount - 1; // Entity contains 1 WL Message and a collection of N BibRecords
+                    _logger.LogInformation("Stored Winlink Message ID {wlmsgid} with {bibcount} bib records to the internal DB.", wlMsgId, bibCount);
                 }
-            }
+
+                 }
             catch (DbUpdateConcurrencyException dbuce)
             {
                 _logger.LogError("Error adding concurrent entity to collection: {msg}", dbuce.Message);
@@ -51,86 +66,58 @@ public class BibReportsCollection : ObservableCollection<WinlinkMessageModel>, I
             }
         }
 
-        return saveCount > 0;
+        return savedEntityCount > 0;
     }
 
-    public async Task<bool> AddEntityToCollectionAsync(WinlinkMessageModel wlMessagePayload)
+    public int BackupCollection()
     {
-        return await Task.Run(() =>
-        {
-            return AddEntityToCollection(wlMessagePayload);
-        });
-    }
+        int itemsCount = 0;
 
-    /// <summary>
-    /// Add a list of entities to this collection and to the local DB.
-    /// </summary>
-    /// <param name="winlinkMessageList"></param>
-    /// <returns></returns>
-    public int AddEntitiesToCollection(List<WinlinkMessageModel> winlinkMessageList)
-    {
-        int saveCount = 0;
-
-        if (winlinkMessageList is not null && winlinkMessageList.Count > 0)
+        if (this.Count > 0)
         {
-            foreach (var message in winlinkMessageList)
+            List<WinlinkMessageModel> items = new();
+
+            lock(LockObject)
             {
-                AddEntityToCollection(message);
+                items = this.ToList<WinlinkMessageModel>();
             }
+
+            _logger.LogInformation("Going to store {num} captured Winlink Messages to a file.", items.Count);
+            itemsCount = _dataExImService.ExportDataToFile(items);
         }
-
-        _logger.LogInformation("Added {num} message entries to the internal DB.", saveCount);
-        return saveCount;
-    }
-
-    public async Task<int> AddEntitiesToCollectionAsync(List<WinlinkMessageModel> winlinkMessageList)
-    {
-        return await Task.Run(() =>
-        {
-            return AddEntitiesToCollection(winlinkMessageList);
-        });
-    }
-
-    public bool BackupCollection()
-    {
-        // todo: return a count of items backed up
-        if (this.Count < 1)
+        else
         {
             _logger.LogInformation("There are no items in memory to back up.");
-            return false;
+            return itemsCount;
         }
-        else
-        {
-            var items = this.ToList<WinlinkMessageModel>();
-            _logger.LogInformation("Going to store {num} items to a file.", items.Count);
-            return DataExImService.ExportDataToFile(items);
-        }
-    }
 
-    public async Task<bool> BackupCollectionAsync()
-    {
-        // todo: return a count of items backed up
-        if (this.Count < 1)
-        {
-            return false;
-        }
-        else
-        {
-            var items = this.ToList<WinlinkMessageModel>();
-            _logger.LogInformation("Going to store {num} items to a file.", items.Count);
-            return await DataExImService.ExportDataToFileAsync(items);
-        }
+        return itemsCount;
     }
 
     public bool RestoreFromBackupFile()
     {
-        var newItems = DataExImService.ImportFileData();
+        int saveCount = 0;
+        var winlinkMessages = _dataExImService.ImportFileData();
 
-        if (newItems.Count > 0)
+        if (winlinkMessages.Count > 0)
         {
-            Clear();
-            AddEntitiesToCollection(newItems);
-            _logger.LogInformation("Restoring {num} items from backup file.", newItems.Count);
+            lock(LockObject)
+            {
+                Clear();
+            }
+
+            if (winlinkMessages is not null && winlinkMessages.Count > 0)
+            {
+                foreach (var message in winlinkMessages)
+                {
+                    if (AddEntityToCollection(message))
+                    {
+                        saveCount++;
+                    }
+                }
+            }
+
+            _logger.LogInformation("Restored {num} items from backup file.", saveCount);
             return true;
         }
         else
@@ -138,13 +125,5 @@ public class BibReportsCollection : ObservableCollection<WinlinkMessageModel>, I
             _logger.LogInformation("No data to restore from backup file.");
             return false;
         }
-    }
-
-    public async Task<bool> RestoreFromBackupFileAsync()
-    {
-        return await Task.Run(() =>
-        {
-            return RestoreFromBackupFile();
-        });
     }
 }

--- a/BFBMX.ServerApi/Collections/IBibReportsCollection.cs
+++ b/BFBMX.ServerApi/Collections/IBibReportsCollection.cs
@@ -5,12 +5,7 @@ namespace BFBMX.ServerApi.Collections
     public interface IBibReportsCollection
     {
         bool AddEntityToCollection(WinlinkMessageModel message);
-        Task<bool> AddEntityToCollectionAsync(WinlinkMessageModel message);
-        int AddEntitiesToCollection(List<WinlinkMessageModel> wlMessages);
-        Task<int> AddEntitiesToCollectionAsync(List<WinlinkMessageModel> wlMessages);
-        bool BackupCollection();
-        Task<bool> BackupCollectionAsync();
+        int BackupCollection();
         bool RestoreFromBackupFile();
-        Task<bool> RestoreFromBackupFileAsync();
     }
 }

--- a/BFBMX.ServerApi/EF/BibMessageContext.cs
+++ b/BFBMX.ServerApi/EF/BibMessageContext.cs
@@ -8,5 +8,5 @@ public class BibMessageContext : DbContext
 {
     public DbSet<WinlinkMessageModel> WinlinkMessageModels { get; set; } = null!;
     public DbSet<FlaggedBibRecordModel> FlaggedBibRecordModels { get; set; } = null!;
-    public BibMessageContext(DbContextOptions options) : base(options) { }
+    public BibMessageContext(DbContextOptions<BibMessageContext> options) : base(options) { }
 }

--- a/BFBMX.ServerApi/Helpers/BibRecordLogger.cs
+++ b/BFBMX.ServerApi/Helpers/BibRecordLogger.cs
@@ -9,7 +9,7 @@ namespace BFBMX.ServerApi.Helpers
         private readonly ILogger<BibRecordLogger> _logger;
 
         private readonly string ParentDirectory = "Documents";
-        private readonly string LogFilename = "BibRecordsLog.txt";
+        private readonly string LogFilename = "BibRecordsServerLog.txt";
 
         public JsonNumberHandling JsonNumerHandling { get; private set; }
 
@@ -33,7 +33,7 @@ namespace BFBMX.ServerApi.Helpers
                 return false;
             }
 
-            string? logDirectory = Environment.GetEnvironmentVariable("BFBMX_FOLDER_NAME");
+            string? logDirectory = Environment.GetEnvironmentVariable("BFBMX_SERVER_FOLDER_NAME");
 
             if (string.IsNullOrEmpty(logDirectory))
             {
@@ -115,20 +115,13 @@ namespace BFBMX.ServerApi.Helpers
                 if (ValidateServerVariables(out string? bfBmxLogPath))
                 {
                     string bfBmxLogFilePath = Path.Combine(bfBmxLogPath!, LogFilename);
-                    //int counter = 0;
 
                     using (StreamWriter file = File.AppendText(bfBmxLogFilePath))
                     {
-                        //foreach (var bibRecord in wlMessagePayload.BibRecords)
-                        //{
-                        //    file.WriteLine(bibRecord.ToTabbedString());
-                        //    counter++;
-                        //}
                         file.Write(wlMessagePayload.ToAccessDatabaseTabbedString());
                     }
 
                     _logger.LogInformation("Wrote 1 Winlink Message payload to log file {logFile}", bfBmxLogFilePath);
-                    //_logger.LogInformation("Write {num} bib records to log file {logFile}", counter, bfBmxLogFilePath);
                 }
                 else
                 {

--- a/BFBMX.ServerApi/Helpers/DataExImService.cs
+++ b/BFBMX.ServerApi/Helpers/DataExImService.cs
@@ -14,7 +14,7 @@ public static class DataExImService
     {
         List<WinlinkMessageModel> result = new();
         string? userProfilePath = Environment.GetEnvironmentVariable("USERPROFILE");
-        string? bfBmxFolderName = Environment.GetEnvironmentVariable("BFBMX_FOLDER_NAME");
+        string? bfBmxFolderName = Environment.GetEnvironmentVariable("BFBMX_SERVER_FOLDER_NAME");
         string? fileName = Environment.GetEnvironmentVariable("BFBMX_BACKUP_FILE_NAME");
 
         if (string.IsNullOrWhiteSpace(bfBmxFolderName) 

--- a/BFBMX.ServerApi/Helpers/DataExImService.cs
+++ b/BFBMX.ServerApi/Helpers/DataExImService.cs
@@ -8,116 +8,96 @@ namespace BFBMX.ServerApi.Helpers;
 /// <summary>
 /// Manages importing and exporting data between files and in-memory database.
 /// </summary>
-public static class DataExImService
+public class DataExImService : IDataExImService
 {
-    public static List<WinlinkMessageModel> ImportFileData()
+    private readonly ILogger<DataExImService> _logger;
+    public string DocumentsDirectoryName => "Documents";
+
+    public DataExImService(ILogger<DataExImService> logger)
+    {
+        _logger = logger;
+    }
+
+    public List<WinlinkMessageModel> ImportFileData()
     {
         List<WinlinkMessageModel> result = new();
-        string? userProfilePath = Environment.GetEnvironmentVariable("USERPROFILE");
-        string? bfBmxFolderName = Environment.GetEnvironmentVariable("BFBMX_SERVER_FOLDER_NAME");
-        string? fileName = Environment.GetEnvironmentVariable("BFBMX_BACKUP_FILE_NAME");
+        string? userProfilePath = ServerEnvFactory.GetuserProfilePath();
+        string? bfBmxFolderName = ServerEnvFactory.GetServerFolderName();
+        string? fileName = ServerEnvFactory.GetServerBackupFilename();
 
-        if (string.IsNullOrWhiteSpace(bfBmxFolderName) 
-            || string.IsNullOrWhiteSpace(fileName)
-            || string.IsNullOrWhiteSpace(userProfilePath))
-        {
-            return result;
-        }
-        else
-        {
-            string backupFilePath = Path.Combine(userProfilePath, "Documents", bfBmxFolderName, fileName);
+        string backupFilePath = Path.Combine(userProfilePath, DocumentsDirectoryName, bfBmxFolderName, fileName);
 
-            if (File.Exists(backupFilePath))
-            {
+        if (File.Exists(backupFilePath))
+        {
 #pragma warning disable IDE0063 // Use simple 'using' statement
-                using (StreamReader backupFile = File.OpenText(backupFilePath))
+            using (StreamReader backupFile = File.OpenText(backupFilePath))
+            {
+                JsonSerializerOptions options = new()
                 {
-                    JsonSerializerOptions options = new()
-                    {
-                        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-                        PropertyNameCaseInsensitive = true
-                    };
+                    NumberHandling = JsonNumberHandling.AllowReadingFromString,
+                    PropertyNameCaseInsensitive = true
+                };
 
-                    WinlinkMessageModel[]? streamedJson = JsonSerializer.Deserialize<WinlinkMessageModel[]>(backupFile.ReadToEnd(), options);
-                    
-                    if (streamedJson is not null)
-                    {
-                        result.AddRange(streamedJson);
-                    }
+                WinlinkMessageModel[]? streamedJson = JsonSerializer.Deserialize<WinlinkMessageModel[]>(backupFile.ReadToEnd(), options);
+
+                if (streamedJson is not null)
+                {
+                    result.AddRange(streamedJson);
                 }
+            }
 #pragma warning restore IDE0063 // Use simple 'using' statement
+        }
+
+        return result;
+    }
+
+    public async Task<List<WinlinkMessageModel>> ImportFileDataAsync()
+    {
+        return await Task.Run(() =>
+        {
+            return ImportFileData();
+        });
+    }
+
+    public int ExportDataToFile(List<WinlinkMessageModel> data)
+    {
+        int itemsCount = 0;
+        string? userProfilePath = ServerEnvFactory.GetuserProfilePath();
+        string? bfBmxFolderName = ServerEnvFactory.GetServerFolderName();
+        string? fileName = ServerEnvFactory.GetServerBackupFilename();
+
+        if (data.Count > 0)
+        {
+            try
+            {
+                string filePath = Path.Combine(userProfilePath, DocumentsDirectoryName, bfBmxFolderName, fileName);
+                File.Create(filePath).Dispose();
+
+                JsonSerializerOptions options = new()
+                {
+                    NumberHandling = JsonNumberHandling.AllowReadingFromString,
+                    PropertyNameCaseInsensitive = true,
+                    WriteIndented = true
+                };
+
+                string json = JsonSerializer.Serialize<List<WinlinkMessageModel>>(data, options);
+                File.WriteAllText(filePath, json);
+                itemsCount = data.Count;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                string msg = $"Unauthorized access to path {userProfilePath}, or {bfBmxFolderName}, or {fileName}.";
+                Debug.WriteLine(msg);
+                Debug.WriteLine($"Related exception message: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                string words = "File access was authorized but an error occurred while logging BibRecords to the file";
+                string msg = $"{words} {userProfilePath}\\{bfBmxFolderName}\\{fileName}: {ex.Message}";
+                Debug.WriteLine(msg);
             }
         }
-        return result;
-    }
 
-    public static async Task<List<WinlinkMessageModel>> ImportFileDataAsync()
-    {
-        return await Task.Run(() =>
-        {
-            return DataExImService.ImportFileData();
-        });
-    }
-
-    public static bool ExportDataToFile(List<WinlinkMessageModel> data)
-    {
-        // todo: return a count of items backed up
-        bool result = false;
-
-        if (data.Count < 1)
-        {
-            return result;
-        }
-
-        string? userProfilePath = Environment.GetEnvironmentVariable("USERPROFILE");
-        string? bfBmxFolderName = Environment.GetEnvironmentVariable("BFBMX_FOLDER_NAME");
-        string? fileName = Environment.GetEnvironmentVariable("BFBMX_BACKUP_FILE_NAME");
-
-        if (string.IsNullOrWhiteSpace(bfBmxFolderName)
-            || string.IsNullOrWhiteSpace(fileName)
-            || string.IsNullOrWhiteSpace(userProfilePath))
-        {
-            return result;
-        }
-
-        try
-        {
-            string filePath = Path.Combine(userProfilePath, "Documents", bfBmxFolderName, fileName);
-            File.Create(filePath).Dispose();
-
-            JsonSerializerOptions options = new()
-            {
-                NumberHandling = JsonNumberHandling.AllowReadingFromString,
-                PropertyNameCaseInsensitive = true,
-                WriteIndented = true
-            };
-
-            string json = JsonSerializer.Serialize<List<WinlinkMessageModel>>(data, options);
-            File.WriteAllText(filePath, json);
-            result = true;
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            string msg = $"Unauthorized access to path {userProfilePath}, or {bfBmxFolderName}, or {fileName}.";
-            Debug.WriteLine(msg);
-            Debug.WriteLine($"Related exception message: {ex.Message}");
-        }
-        catch (Exception ex)
-        {
-            string words = "File access was authorized but an error occurred while logging BibRecords to the file";
-            string msg = $"{words} {userProfilePath}\\{bfBmxFolderName}\\{fileName}: {ex.Message}";
-            Debug.WriteLine(msg);
-        }
-
-        return result;
-    }
-
-    public static async Task<bool> ExportDataToFileAsync(List<WinlinkMessageModel> data)
-    {
-        // todo: return a count of items backed up
-        return await Task.Run(() =>
-        {
-            return DataExImService.ExportDataToFile(data);
-        });
+        return itemsCount;
     }
 }

--- a/BFBMX.ServerApi/Helpers/IBibRecordLogger.cs
+++ b/BFBMX.ServerApi/Helpers/IBibRecordLogger.cs
@@ -7,6 +7,5 @@ namespace BFBMX.ServerApi.Helpers
         bool ValidateServerVariables(out string? bfBmxLogPath);
         bool LogWinlinkMessagePayloadToJsonAuditFile(WinlinkMessageModel wlMessagePayload);
         bool LogFlaggedRecordsTabDelimited(WinlinkMessageModel wlMessagePayload);
-        Task<bool> LogFlaggedRecordsTabDelimitedAsync(WinlinkMessageModel wlMessagePayload);
     }
 }

--- a/BFBMX.ServerApi/Helpers/IDataExImService.cs
+++ b/BFBMX.ServerApi/Helpers/IDataExImService.cs
@@ -1,0 +1,13 @@
+﻿using BFBMX.Service.Models;
+
+namespace BFBMX.ServerApi.Helpers
+{
+    public interface IDataExImService
+    {
+        string DocumentsDirectoryName { get; }
+
+        int ExportDataToFile(List<WinlinkMessageModel> data);
+        List<WinlinkMessageModel> ImportFileData();
+        Task<List<WinlinkMessageModel>> ImportFileDataAsync();
+    }
+}

--- a/BFBMX.ServerApi/Helpers/ServerEnvFactory.cs
+++ b/BFBMX.ServerApi/Helpers/ServerEnvFactory.cs
@@ -1,0 +1,34 @@
+﻿namespace BFBMX.ServerApi.Helpers
+{
+    public static class ServerEnvFactory
+    {
+        public static string GetuserProfilePath()
+        {
+            string? userProfilePath = Environment.GetEnvironmentVariable("USERPROFILE");
+            string upPath = string.IsNullOrWhiteSpace(userProfilePath) ? @"C:\" : userProfilePath;
+            return upPath;
+        }
+
+        public static string GetServerFolderName()
+        {
+            string? logDirectory = Environment.GetEnvironmentVariable("BFBMX_SERVER_FOLDER_NAME");
+            string sfName = string.IsNullOrWhiteSpace(logDirectory) ? "BFBMX" : logDirectory;
+            return sfName;
+        }
+
+        public static string GetServerBackupFilename()
+        {
+            string? bbBackupFilename = Environment.GetEnvironmentVariable("BFBMX_BACKUP_FILE_NAME");
+            string backupFileName = string.IsNullOrWhiteSpace(bbBackupFilename) ? "BFBMX-LocalDb-Backup.txt" : bbBackupFilename;
+            return backupFileName;
+        }
+
+        public static string GetServerLogPath()
+        {
+            string userProfilePath = GetuserProfilePath();
+            string logDirectory = GetServerFolderName();
+            string serverLogPath = System.IO.Path.Combine(userProfilePath, "Documents", logDirectory);
+            return serverLogPath;
+        }
+    }
+}

--- a/BFBMX.ServerApi/Program.cs
+++ b/BFBMX.ServerApi/Program.cs
@@ -10,11 +10,12 @@ var builder = WebApplication.CreateBuilder(args);
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 
-// entity framework
+// entity framework must be configured and added as TRANSIENT in ASP.NET IoC
 builder.Services.AddDbContextFactory <BibMessageContext> (options =>
 {
     options.UseInMemoryDatabase($"BFBMX-{Guid.NewGuid()}");
 });
+builder.Services.AddTransient<BibMessageContext>();
 
 builder.Services.AddSwaggerGen();
 builder.Services.AddLogging();

--- a/BFBMX.ServerApi/Program.cs
+++ b/BFBMX.ServerApi/Program.cs
@@ -15,7 +15,6 @@ builder.Services.AddDbContextFactory <BibMessageContext> (options =>
 {
     options.UseInMemoryDatabase($"BFBMX-{Guid.NewGuid()}");
 });
-builder.Services.AddTransient<BibMessageContext>();
 
 builder.Services.AddSwaggerGen();
 builder.Services.AddLogging();

--- a/BFBMX.Service/Helpers/IFileProcessor.cs
+++ b/BFBMX.Service/Helpers/IFileProcessor.cs
@@ -1,0 +1,17 @@
+﻿using BFBMX.Service.Models;
+
+namespace BFBMX.Service.Helpers
+{
+    public interface IFileProcessor
+    {
+        bool GetBibMatches(List<FlaggedBibRecordModel> emptyBibList, string[] fileDataLines, string pattern);
+        string[] GetFileData(string fullFilePath);
+        string GetMessageId(string fileData);
+        List<FlaggedBibRecordModel> GetSloppyMatches(string[] lines);
+        List<FlaggedBibRecordModel> GetStrictMatches(string[] lines);
+        bool ProcessBibs(List<FlaggedBibRecordModel> bibRecords, string[] lines);
+        WinlinkMessageModel ProcessWinlinkMessageFile(DateTime timestamp, string machineName, string filePath);
+        string RecordsArrayToString(string[] fileData);
+        bool WriteWinlinkMessageToFile(WinlinkMessageModel msg, string filepath);
+    }
+}

--- a/BFBMX.Service/Models/DiscoveredFileModel.cs
+++ b/BFBMX.Service/Models/DiscoveredFileModel.cs
@@ -37,6 +37,7 @@ namespace BFBMX.Service.Models
         public int CompareTo(DiscoveredFileModel? other)
         {
             if (other == null) return 1;
+            // todo: Find out from stakeholders if filename only collisions should be considered
             return string.Compare(FullFilePath, other.FullFilePath, StringComparison.Ordinal);
         }
 

--- a/BFBMX.Service/Models/WinlinkMessageModel.cs
+++ b/BFBMX.Service/Models/WinlinkMessageModel.cs
@@ -36,9 +36,7 @@ public class WinlinkMessageModel
     public string ToFilename()
     {
         // learn.microsoft.com: 2009-06-15T13:45:30 (DateTimeKind.Local) -> 2009-06-15T13:45:30
-        // string sortableFormatPattern = ClientDateTime.ToString("s");
         string customFormatPattern = MessageDateTime.ToString("yyyy-MM-ddTHH-mm-ss");
-        //return $"{ClientHostname}-{customFormatPattern}.txt"; // option
         return $"{WinlinkMessageId}-{customFormatPattern}.txt";
     }
 
@@ -72,5 +70,30 @@ public class WinlinkMessageModel
         }
 
         return sbBibData.ToString();
+    }
+
+    // for sake of comparing entities
+    public override bool Equals(object? obj)
+    {
+        if (obj is WinlinkMessageModel other)
+        {
+            return WinlinkMessageId == other.WinlinkMessageId
+                && MessageDateTime == other.MessageDateTime
+                && ClientHostname == other.ClientHostname
+                && (BibRecords?.Count == other.BibRecords?.Count);
+        }
+
+        return false;
+    }
+
+    // for sake of comparing entities
+    public override int GetHashCode()
+    {
+        int hash = 17;
+        hash = hash * 23 + (WinlinkMessageId?.GetHashCode() ?? 0);
+        hash = hash * 23 + MessageDateTime.GetHashCode();
+        hash = hash * 23 + (ClientHostname?.GetHashCode() ?? 0);
+        hash = hash * 23 + (BibRecords?.Count.GetHashCode() ?? 0);
+        return hash;
     }
 }


### PR DESCRIPTION
- [x] Fix server backups so the file writes out all collection items.
- [x] Ensure Exceptions related to backups are caught and handled.

Several changes were necessary to make the fixes:

- [x] Avoid using static classes for parallel or potentially async operations.
- [x] Ensure dependencies are injected into IoC.
- [x] Utilize a Lock handle to ensure file and object access when required.
