### PR TITLE
Dev DateTimeStamp Alternative

### DIFF
--- a/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
@@ -67,10 +67,10 @@ namespace BFBMX.Desktop.ViewModels
         /// <param name="e"></param>
         public async void HandleFileCreatedAsync(object sender, FileSystemEventArgs e)
         {
-            _logger.LogInformation("File creation detected, waiting 1 second before reading contents.");
             string? discoveredFilepath = e.FullPath ?? "unknown - check logs!";
-            _logger.LogInformation("Discovered file path {filepath}. Enqueuing to be processed.", discoveredFilepath);
             DiscoveredFileModel newFile = new(discoveredFilepath);
+            DateTime fileTimeStamp = newFile.FileTimeStamp;
+            _logger.LogInformation("Discovered file path {filepath} creation stamp {filedatetime} for processing.", discoveredFilepath, fileTimeStamp);
             await _discoveredFiles.EnqueueAsync(newFile);
 
             // insert the new item into the collection on the UI Thread (WPF requirement)
@@ -88,15 +88,13 @@ namespace BFBMX.Desktop.ViewModels
 
             _logger.LogInformation("Path {discoveredFilepath} sent to screen for display.", discoveredFilepath);
 
-            /***** moved from DiscoveredFilesCollection *****/
-
             // get machine name for File Processor
             string? hostname = Environment.MachineName;
             string machineName = string.IsNullOrWhiteSpace(hostname) ? "Unknown" : hostname;
 
             // process the file for bib records
             await Task.Delay(1000);
-            _logger.LogInformation("Sending file {newFile} to file processor.", newFile.FullFilePath);
+            _logger.LogInformation("Sending file {newFile} created at {fileTimeStamp} to file processor.", newFile.FullFilePath, newFile.FileTimeStamp);
             WinlinkMessageModel winlinkMessage = _fileProcessor.ProcessWinlinkMessageFile(newFile.FileTimeStamp, machineName, newFile.FullFilePath);
 
             // No bib reports found, log and return

--- a/BFBMX.ServerApi/Helpers/IBibRecordLogger.cs
+++ b/BFBMX.ServerApi/Helpers/IBibRecordLogger.cs
@@ -7,5 +7,6 @@ namespace BFBMX.ServerApi.Helpers
         bool ValidateServerVariables(out string? bfBmxLogPath);
         bool LogWinlinkMessagePayloadToJsonAuditFile(WinlinkMessageModel wlMessagePayload);
         bool LogFlaggedRecordsTabDelimited(WinlinkMessageModel wlMessagePayload);
+        bool LogWinlinkMessagePayloadToTabDelimitedFile(WinlinkMessageModel wlMessagePayload);
     }
 }

--- a/BFBMX.ServerApi/Program.cs
+++ b/BFBMX.ServerApi/Program.cs
@@ -81,25 +81,16 @@ app.MapPost("/WinlinkMessage", (WinlinkMessageModel request) =>
     bool loggedInTabDelimitedFormat = false;
     try
     {
-        loggedInTabDelimitedFormat = bibRecordLogger.LogFlaggedRecordsTabDelimited(request);
+        //loggedInTabDelimitedFormat = bibRecordLogger.LogFlaggedRecordsTabDelimited(request);
+        loggedInTabDelimitedFormat = bibRecordLogger.LogWinlinkMessagePayloadToTabDelimitedFile(request);
     }
     catch (Exception ex)
     {
         app.Logger.LogWarning("MapPost Exception caught at LogFlaggedRecordsTabDelimited(request) call! {exceptionMessage}\n{exceptionTrace}", ex.Message, ex.StackTrace);
     }
 
-    bool wroteToJsonAuditFile = false;
-    try
-    {
-        wroteToJsonAuditFile = bibRecordLogger.LogWinlinkMessagePayloadToJsonAuditFile(request);
-    }
-        catch (Exception ex)
-    {
-        app.Logger.LogWarning("MapPost Exception caught at LogWinlinkMessagePayloadToJsonAuditFile(request) call! {exceptionMessage}\n{exceptionTrace}", ex.Message, ex.StackTrace);
-    }
-
     // return 200 OK or 400 Bad Request
-    if (addedRecordsToCollection && loggedInTabDelimitedFormat && wroteToJsonAuditFile)
+    if (addedRecordsToCollection && loggedInTabDelimitedFormat)
     {
         Results.Ok();
     }

--- a/BFBMX.Service.Test/Helpers/BibRecordLoggerTests.cs
+++ b/BFBMX.Service.Test/Helpers/BibRecordLoggerTests.cs
@@ -1,0 +1,164 @@
+using BFBMX.ServerApi.Helpers;
+using BFBMX.Service.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.IO;
+using Xunit;
+
+namespace BFBMX.Service.Test.Helpers
+{
+    public class BibRecordLoggerTests
+    {
+        [Fact]
+        public void LogWinlinkMessagePayloadToTabDelimitedFile_ValidPayload_ReturnsTrue()
+        {
+            // todo: validate and update this test.
+            // todo: write addition test cases for false returns
+            // Arrange
+            var logger = new NullLogger<BibRecordLogger>();
+            var bibRecordLogger = new BibRecordLogger(logger);
+            var winlinkMessagePayload = new WinlinkMessageModel();
+
+            // Act
+            var result = bibRecordLogger.LogWinlinkMessagePayloadToTabDelimitedFile(winlinkMessagePayload);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        //[Fact]
+        //public void ValidateServerVariables_WhenUserProfilePathIsNull_ReturnsFalse()
+        //{
+        //    // Arrange
+        //    NullLogger<BibRecordLogger> logger = new();
+        //    BibRecordLogger bibRecordLogger = new(logger);
+        //    string? currentUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        //    Environment.SetEnvironmentVariable("USERPROFILE", null);
+
+        //    // Act
+        //    bool result = bibRecordLogger.ValidateServerVariables(out string? bfBmxLogPath);
+
+        //    // Assert
+        //    if (result is true)
+        //    {
+        //        Environment.SetEnvironmentVariable("USERPROFILE", currentUserProfile);
+        //        Assert.False(result, "ValidateServerVariables returned true when USERPROFILE was null but it should have returned false.");
+        //    }
+
+        //    Environment.SetEnvironmentVariable("USERPROFILE", currentUserProfile);
+        //    Assert.Equal(string.Empty, bfBmxLogPath);
+        //}
+
+        [Fact]
+        public void ValidateServerVariables_WhenLogDirectoryIsNull_ReturnsFalse()
+        {
+            // Arrange
+            var logger = new NullLogger<BibRecordLogger>();
+            var bibRecordLogger = new BibRecordLogger(logger);
+            //Environment.SetEnvironmentVariable("USERPROFILE", "C:\\Users\\TestUser");
+            Environment.SetEnvironmentVariable("BFBMX_SERVER_FOLDER_NAME", null);
+
+            // Act
+            var result = bibRecordLogger.ValidateServerVariables(out string? bfBmxLogPath);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(string.Empty, bfBmxLogPath);
+        }
+
+        [Fact]
+        public void ValidateServerVariables_WhenLogDirectoryDoesNotExist_CreatesDirectory()
+        {
+            // Arrange
+            var logger = new NullLogger<BibRecordLogger>();
+            var bibRecordLogger = new BibRecordLogger(logger);
+            //Environment.SetEnvironmentVariable("USERPROFILE", "C:\\Users\\TestUser");
+            Environment.SetEnvironmentVariable("BFBMX_SERVER_FOLDER_NAME", "Logs");
+            var expectedLogPath = Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), "Documents", "Logs");
+
+            // Act
+            var result = bibRecordLogger.ValidateServerVariables(out string? bfBmxLogPath);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedLogPath, bfBmxLogPath);
+            Assert.True(Directory.Exists(expectedLogPath));
+
+            // cleanup
+            if (File.Exists(expectedLogPath))
+            {
+                Directory.Delete(expectedLogPath);
+            }
+        }
+
+        [Fact]
+        public void LogWinlinkMessagePayloadToJsonAuditFile_WhenValidationFails_ReturnsFalse()
+        {
+            // Arrange
+            var logger = new NullLogger<BibRecordLogger>();
+            var bibRecordLogger = new BibRecordLogger(logger);
+            var wlMessagePayload = new WinlinkMessageModel();
+
+            // Act
+            bool result = bibRecordLogger.LogWinlinkMessagePayloadToJsonAuditFile(wlMessagePayload);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        //[Fact]
+        //public void LogWinlinkMessagePayloadToJsonAuditFile_WhenValidationSucceeds_WritesToFile()
+        //{
+        //    // Arrange
+        //    var logger = new NullLogger<BibRecordLogger>();
+        //    var bibRecordLogger = new BibRecordLogger(logger);
+        //    var wlMessagePayload = new WinlinkMessageModel
+        //    {
+        //        // Set properties of the payload
+        //    };
+
+        //    // Act
+        //    var result = bibRecordLogger.LogWinlinkMessagePayloadToJsonAuditFile(wlMessagePayload);
+
+        //    // Assert
+        //    Assert.True(result);
+        //    // Add assertions to verify the file content
+        //}
+
+        [Fact]
+        public void LogFlaggedRecordsTabDelimited_WhenValidationFails_ReturnsFalse()
+        {
+            // Arrange
+            var logger = new NullLogger<BibRecordLogger>();
+            var bibRecordLogger = new BibRecordLogger(logger);
+            var wlMessagePayload = new WinlinkMessageModel();
+
+            // Act
+            var result = bibRecordLogger.LogFlaggedRecordsTabDelimited(wlMessagePayload);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void LogFlaggedRecordsTabDelimited_WhenValidationSucceeds_WritesToFile()
+        {
+            // todo: complete writing this test!
+            Assert.True(false);
+            // Arrange
+            var logger = new NullLogger<BibRecordLogger>();
+            var bibRecordLogger = new BibRecordLogger(logger);
+            var wlMessagePayload = new WinlinkMessageModel
+            {
+                // Set properties of the payload
+            };
+
+            // Act
+            var result = bibRecordLogger.LogFlaggedRecordsTabDelimited(wlMessagePayload);
+
+            // Assert
+            Assert.True(result);
+            // Add assertions to verify the file content
+        }
+    }
+}

--- a/BFBMX.Service.Test/Helpers/FileSystemMonitorTests.cs
+++ b/BFBMX.Service.Test/Helpers/FileSystemMonitorTests.cs
@@ -58,8 +58,6 @@ namespace BFBMX.Service.Test.Helpers
             var expectedPath = tempPath;
 
             // capture the watcher object and ensure automatic disposal if a test fails
-            //using var actualWatcher =
-            //    FSWatcherFactory.Create(HandleFileCreated, HandleFileWatherError, expectedPath!);
             var actualWatcher = FSWatcherFactory.Create(HandleFileCreated, HandleFileWatherError, expectedPath!, BravoMonitorName);
 
             // verify starting conditions

--- a/BFBMX.Service.Test/Models/WinlinkMessageModelTests.cs
+++ b/BFBMX.Service.Test/Models/WinlinkMessageModelTests.cs
@@ -14,8 +14,9 @@ public class WinlinkMessageModelTests
         var sut = new WinlinkMessageModel
         {
             WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateTime = new DateTime(2024, 01, 02, 12, 11, 10),
+            MessageDateStamp = new DateTime(2024, 01, 02, 12, 11, 10),
             ClientHostname = "test-hostname",
+            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
             BibRecords = new List<FlaggedBibRecordModel>
       {
           new FlaggedBibRecordModel
@@ -56,8 +57,9 @@ public class WinlinkMessageModelTests
         var sut = new WinlinkMessageModel
         {
             WinlinkMessageId = null,
-            MessageDateTime = new DateTime(),
+            MessageDateStamp = new DateTime(),
             ClientHostname = null,
+            FileCreatedTimeStamp = new DateTime(),
             BibRecords = new List<FlaggedBibRecordModel>
             {
                 new FlaggedBibRecordModel()
@@ -66,7 +68,7 @@ public class WinlinkMessageModelTests
 
         // test nullable fields
         Assert.Null(sut.WinlinkMessageId);
-        // If client datetime is null there is nothing this code could do about it
+        // DateTime type properties cannot be null
         Assert.Null(sut.ClientHostname);
         Assert.True(sut.BibRecords.Count > 0);
 
@@ -86,8 +88,9 @@ public class WinlinkMessageModelTests
         var sut = new WinlinkMessageModel
         {
             WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateTime = new DateTime(2024, 01, 02, 13, 12, 11),
+            MessageDateStamp = new DateTime(2024, 01, 02, 13, 12, 11),
             ClientHostname = "test-hostname",
+            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
             BibRecords = new List<FlaggedBibRecordModel>
       {
             new FlaggedBibRecordModel
@@ -99,9 +102,11 @@ public class WinlinkMessageModelTests
             Location = "test-location",
             DataWarning = false,
             }
-        }
+            }
         };
-        var expected = "ABCDEFGHIJKL-2024-01-02T13-12-11.txt";
+
+        // todo: Should it be Message date-time, or file created date-time?
+        var expected = "ABCDEFGHIJKL-2023-08-13T23-22-21.txt";
         var actual = sut.ToFilename();
         Assert.Equal(expected, actual);
     }
@@ -112,8 +117,9 @@ public class WinlinkMessageModelTests
         var sut = new WinlinkMessageModel
         {
             WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateTime = new DateTime(2024, 01, 02, 13, 12, 11),
+            MessageDateStamp = new DateTime(2024, 01, 02, 13, 12, 11),
             ClientHostname = "test-hostname",
+            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
             BibRecords = new List<FlaggedBibRecordModel>
             {
                 new FlaggedBibRecordModel
@@ -128,8 +134,13 @@ public class WinlinkMessageModelTests
             }
         };
 
-        var singleBibExpected = "{\"WinlinkMessageId\":\"ABCDEFGHIJKL\",\"MessageDateTime\":\"2024-01-02T13:12:11\",\"ClientHostname\":\"test-hostname\",\"BibRecords\":[" +
-            "{\"BibNumber\":1,\"Action\":\"IN\",\"BibTimeOfDay\":\"1314\",\"DayOfMonth\":2,\"Location\":\"test-location\",\"DataWarning\":false}]}";
+        var singleBibExpected =
+            "{\"WinlinkMessageId\":\"ABCDEFGHIJKL\"," +
+            "\"MessageDateStamp\":\"2024-01-02T13:12:11\"," +
+            "\"ClientHostname\":\"test-hostname\"," +
+            "\"FileCreatedTimeStamp\":\"2023-08-13T23:22:21\"," +
+            "\"BibRecords\":" +
+            "[{\"BibNumber\":1,\"Action\":\"IN\",\"BibTimeOfDay\":\"1314\",\"DayOfMonth\":2,\"Location\":\"test-location\",\"DataWarning\":false}]}";
         var singleBibActual = sut.ToJsonString();
         
         Debug.WriteLine($"singleBibExpected:\r\n{singleBibExpected}");
@@ -148,7 +159,12 @@ public class WinlinkMessageModelTests
 
         sut.BibRecords.Add(newRecord);
 
-        var twoBibsExpected = "{\"WinlinkMessageId\":\"ABCDEFGHIJKL\",\"MessageDateTime\":\"2024-01-02T13:12:11\",\"ClientHostname\":\"test-hostname\",\"BibRecords\":[" +
+        var twoBibsExpected = 
+            "{\"WinlinkMessageId\":\"ABCDEFGHIJKL\"," +
+            "\"MessageDateStamp\":\"2024-01-02T13:12:11\"," +
+            "\"ClientHostname\":\"test-hostname\"," +
+            "\"FileCreatedTimeStamp\":\"2023-08-13T23:22:21\"," +
+            "\"BibRecords\":[" +
             "{\"BibNumber\":1,\"Action\":\"IN\",\"BibTimeOfDay\":\"1314\",\"DayOfMonth\":2,\"Location\":\"test-location\",\"DataWarning\":false}," +
             "{\"BibNumber\":1,\"Action\":\"OUTT\",\"BibTimeOfDay\":\"2014\",\"DayOfMonth\":2,\"Location\":\"test-location\",\"DataWarning\":true}]}";
         var twoBibsActual = sut.ToJsonString();
@@ -164,8 +180,9 @@ public class WinlinkMessageModelTests
         var sut = new WinlinkMessageModel
         {
             WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateTime = new DateTime(2024, 01, 02, 13, 12, 11),
+            MessageDateStamp = new DateTime(2024, 01, 02, 13, 12, 11),
             ClientHostname = "test-hostname",
+            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
             BibRecords = new List<FlaggedBibRecordModel>
             {
                 new FlaggedBibRecordModel
@@ -180,7 +197,12 @@ public class WinlinkMessageModelTests
             }
         };
 
-        var expected = "{\"WinlinkMessageId\":\"ABCDEFGHIJKL\",\"MessageDateTime\":\"2024-01-02T13:12:11\",\"ClientHostname\":\"test-hostname\",\"BibRecords\":[{\"BibNumber\":1,\"Action\":\"IN\",\"BibTimeOfDay\":\"13145\",\"DayOfMonth\":2,\"Location\":\"test-location\",\"DataWarning\":true}]}";
+        var expected = 
+            "{\"WinlinkMessageId\":\"ABCDEFGHIJKL\"," +
+            "\"MessageDateStamp\":\"2024-01-02T13:12:11\"," +
+            "\"ClientHostname\":\"test-hostname\"," +
+            "\"FileCreatedTimeStamp\":\"2023-08-13T23:22:21\"," +
+            "\"BibRecords\":[{\"BibNumber\":1,\"Action\":\"IN\",\"BibTimeOfDay\":\"13145\",\"DayOfMonth\":2,\"Location\":\"test-location\",\"DataWarning\":true}]}";
         var actual = sut.ToJsonString();
         Assert.Equal(expected, actual);
     }
@@ -191,8 +213,9 @@ public class WinlinkMessageModelTests
         var sut = new WinlinkMessageModel
         {
             WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateTime = new DateTime(2024, 01, 02, 13, 12, 11),
+            MessageDateStamp = new DateTime(2024, 01, 02, 13, 12, 11),
             ClientHostname = "test-hostname",
+            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
             BibRecords = new List<FlaggedBibRecordModel>
             {
                 new FlaggedBibRecordModel
@@ -228,8 +251,9 @@ public class WinlinkMessageModelTests
         var sut = new WinlinkMessageModel
         {
             WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateTime = new DateTime(2024, 01, 02, 13, 12, 11),
+            MessageDateStamp = new DateTime(2024, 01, 02, 13, 12, 11),
             ClientHostname = "test-hostname",
+            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
             BibRecords = new List<FlaggedBibRecordModel>
             {
                 bibEntry
@@ -274,8 +298,9 @@ public class WinlinkMessageModelTests
         var sut = new WinlinkMessageModel
         {
             WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateTime = new DateTime(2024, 01, 02, 13, 12, 11),
+            MessageDateStamp = new DateTime(2024, 01, 02, 13, 12, 11),
             ClientHostname = "test-hostname",
+            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
             BibRecords = new List<FlaggedBibRecordModel>
             {
                 bibEntry
@@ -305,8 +330,9 @@ public class WinlinkMessageModelTests
         var sut = new WinlinkMessageModel
         {
             WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateTime = new DateTime(2024, 01, 02, 13, 12, 11),
+            MessageDateStamp = new DateTime(2024, 01, 02, 13, 12, 11),
             ClientHostname = "test-hostname",
+            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
             BibRecords = new List<FlaggedBibRecordModel>
             {
                 bibEntry

--- a/BFBMX.Service.Test/Models/WinlinkMessageModelTests.cs
+++ b/BFBMX.Service.Test/Models/WinlinkMessageModelTests.cs
@@ -7,6 +7,9 @@ public class WinlinkMessageModelTests
 {
     public string NoDataWarningText => "NOMINAL";
     public string DataWarningText => "ALERT";
+    public static DateTime JanuarySecond => new DateTime(2024,01,02,03,04,05);
+    public static DateTime FebruaryThird => new DateTime(2024,02,03,04,05,06);
+    public static DateTime MarchFourth => new DateTime(2024, 03, 04, 05, 06, 07);
 
     [Fact]
     public void InstantiateAllFields()
@@ -106,7 +109,7 @@ public class WinlinkMessageModelTests
         };
 
         // todo: Should it be Message date-time, or file created date-time?
-        var expected = "ABCDEFGHIJKL-2023-08-13T23-22-21.txt";
+        var expected = "ABCDEFGHIJKL.txt";
         var actual = sut.ToFilename();
         Assert.Equal(expected, actual);
     }
@@ -142,7 +145,7 @@ public class WinlinkMessageModelTests
             "\"BibRecords\":" +
             "[{\"BibNumber\":1,\"Action\":\"IN\",\"BibTimeOfDay\":\"1314\",\"DayOfMonth\":2,\"Location\":\"test-location\",\"DataWarning\":false}]}";
         var singleBibActual = sut.ToJsonString();
-        
+
         Debug.WriteLine($"singleBibExpected:\r\n{singleBibExpected}");
         Debug.WriteLine($"singleBibActual:\r\n{singleBibActual}");
         Assert.Equal(singleBibExpected, singleBibActual);
@@ -159,7 +162,7 @@ public class WinlinkMessageModelTests
 
         sut.BibRecords.Add(newRecord);
 
-        var twoBibsExpected = 
+        var twoBibsExpected =
             "{\"WinlinkMessageId\":\"ABCDEFGHIJKL\"," +
             "\"MessageDateStamp\":\"2024-01-02T13:12:11\"," +
             "\"ClientHostname\":\"test-hostname\"," +
@@ -197,7 +200,7 @@ public class WinlinkMessageModelTests
             }
         };
 
-        var expected = 
+        var expected =
             "{\"WinlinkMessageId\":\"ABCDEFGHIJKL\"," +
             "\"MessageDateStamp\":\"2024-01-02T13:12:11\"," +
             "\"ClientHostname\":\"test-hostname\"," +
@@ -234,85 +237,6 @@ public class WinlinkMessageModelTests
         var actual = sut.BibRecords[0].ToTabbedString();
         Assert.Equal(expected, actual);
     }
-
-    [Fact]
-    public void MessageToServerAuditTabbedString()
-    {
-        var bibEntry = new FlaggedBibRecordModel
-        {
-            BibNumber = 1,
-            @Action = "IN",
-            BibTimeOfDay = "1314",
-            DayOfMonth = 2,
-            Location = "test-location",
-            DataWarning = false,
-        };
-
-        var sut = new WinlinkMessageModel
-        {
-            WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateStamp = new DateTime(2024, 01, 02, 13, 12, 11),
-            ClientHostname = "test-hostname",
-            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
-            BibRecords = new List<FlaggedBibRecordModel>
-            {
-                bibEntry
-            }
-        };
-
-        var oneLineExpected = $"ABCDEFGHIJKL\ttest-hostname\t{NoDataWarningText}\t1\tIN\t1314\t2\ttest-location\r\n";
-        var oneLineActual = sut.ToServerAuditTabbedString();
-        Debug.WriteLine($"Expected:\r\n{oneLineExpected}\r\nActual:\r\n{oneLineActual}");
-        Assert.Equal(oneLineExpected, oneLineActual);
-
-        var newRecord = new FlaggedBibRecordModel()
-        {
-            BibNumber = 1,
-            Action = "OUTT",
-            BibTimeOfDay = "2014",
-            DayOfMonth = 2,
-            Location = "test-location",
-            DataWarning = true
-        };
-        sut.BibRecords.Add(newRecord);
-
-        var twoLinesExpected = $"ABCDEFGHIJKL\ttest-hostname\t{NoDataWarningText}\t1\tIN\t1314\t2\ttest-location\r\nABCDEFGHIJKL\ttest-hostname\t{DataWarningText}\t1\tOUTT\t2014\t2\ttest-location\r\n";
-        string twoLinesActual = sut.ToServerAuditTabbedString();
-        Debug.WriteLine($"Expected:\r\n{twoLinesExpected}\r\nActual:\r\n{twoLinesActual}");
-        Assert.Equal(twoLinesExpected, twoLinesActual);
-    }
-
-    [Fact]
-    public void MessageToStringWithWarning()
-    {
-        var bibEntry = new FlaggedBibRecordModel
-        {
-            BibNumber = 1,
-            @Action = "IN",
-            BibTimeOfDay = "1314",
-            DayOfMonth = 2,
-            Location = "test-location",
-            DataWarning = true,
-        };
-
-        var sut = new WinlinkMessageModel
-        {
-            WinlinkMessageId = "ABCDEFGHIJKL",
-            MessageDateStamp = new DateTime(2024, 01, 02, 13, 12, 11),
-            ClientHostname = "test-hostname",
-            FileCreatedTimeStamp = new DateTime(2023, 08, 13, 23, 22, 21),
-            BibRecords = new List<FlaggedBibRecordModel>
-            {
-                bibEntry
-            }
-        };
-
-        var expected = $"ABCDEFGHIJKL\ttest-hostname\t{DataWarningText}\t1\tIN\t1314\t2\ttest-location\r\n";
-        var oneLIneActual = sut.ToServerAuditTabbedString();
-        Debug.WriteLine($"Expected:\r\n{expected}\r\nActual:\r\n{oneLIneActual}");
-        Assert.Equal(expected, oneLIneActual);
-    }
-
 
     [Fact]
     public void MessageToAccessDatabaseTabbedString()
@@ -359,5 +283,159 @@ public class WinlinkMessageModelTests
         string twoLinesActual = sut.ToAccessDatabaseTabbedString();
         Debug.WriteLine($"Expected:\r\n{twoLinesExpected}\r\nActual:\r\n{twoLinesActual}");
         Assert.Equal(twoLinesExpected, twoLinesActual);
+    }
+
+    [Fact]
+    public void GetHashCodeReturnsUniqueHashCode()
+    {
+        var winlinkMessage1 = new WinlinkMessageModel
+        {
+            WinlinkMessageId = "ABC123",
+            MessageDateStamp = MarchFourth,
+            ClientHostname = "localhost",
+            FileCreatedTimeStamp = MarchFourth.AddDays(1),
+            BibRecords = new List<FlaggedBibRecordModel>()
+        };
+
+        var winlinkMessage2 = new WinlinkMessageModel
+        {
+            WinlinkMessageId = "XYZ789",
+            MessageDateStamp = MarchFourth.AddDays(1),
+            ClientHostname = "localhost",
+            FileCreatedTimeStamp = MarchFourth.AddDays(1),
+            BibRecords = new List<FlaggedBibRecordModel>()
+        };
+
+        var hashCode1 = winlinkMessage1.GetHashCode();
+        var hashCode2 = winlinkMessage2.GetHashCode();
+
+        Assert.NotEqual(hashCode1, hashCode2);
+    }
+
+    [Fact]
+    public void OverrideEqualsReturnsTrueForEqualObjects()
+    {
+        var winlinkMessage1 = new WinlinkMessageModel
+        {
+            WinlinkMessageId = "ABC123",
+            MessageDateStamp = MarchFourth.AddDays(-1),
+            ClientHostname = "localhost",
+            FileCreatedTimeStamp = MarchFourth,
+            BibRecords = new List<FlaggedBibRecordModel>()
+        };
+
+        var winlinkMessage2 = new WinlinkMessageModel
+        {
+            WinlinkMessageId = "ABC123",
+            MessageDateStamp = MarchFourth.AddDays(-1),
+            ClientHostname = "localhost",
+            FileCreatedTimeStamp = MarchFourth,
+            BibRecords = new List<FlaggedBibRecordModel>()
+        };
+
+        Assert.True(winlinkMessage1.Equals(winlinkMessage2));
+    }
+
+    [Fact]
+    public void OverrideEqualsReturnsFalseForNotEqualObjects()
+    {
+        var winlinkMessage1 = new WinlinkMessageModel
+        {
+            WinlinkMessageId = "ABC123DEF456",
+            MessageDateStamp = JanuarySecond,
+            ClientHostname = "localhost",
+            FileCreatedTimeStamp = FebruaryThird,
+            BibRecords = new List<FlaggedBibRecordModel>()
+        };
+
+        var winlinkMessage2 = new WinlinkMessageModel
+        {
+            WinlinkMessageId = "ABC123DEF856",
+            MessageDateStamp = MarchFourth,
+            ClientHostname = "localhost",
+            FileCreatedTimeStamp = JanuarySecond,
+            BibRecords = new List<FlaggedBibRecordModel>()
+        };
+
+        Assert.False(winlinkMessage1.Equals(winlinkMessage2));
+    }
+
+    [Fact]
+    public void PrintableDateTimeReturnsCorrectFormat()
+    {
+        WinlinkMessageModel sut = new();
+        string expectedResult = "2024-01-02T03-04-05";
+        Assert.True(expectedResult.Equals(sut.PrintableMsgDateTime(JanuarySecond)));
+    }
+
+    [Fact]
+    public void HasDataWarning()
+    {
+        FlaggedBibRecordModel alpha = new()
+        {
+            BibNumber = 1,
+            @Action = "IN",
+            BibTimeOfDay = "1314",
+            DayOfMonth = 2,
+            Location = "test-location",
+            DataWarning = false,
+        };
+
+        FlaggedBibRecordModel bravo = new()
+        {
+            BibNumber = 2,
+            @Action = "OUT",
+            BibTimeOfDay = "2014",
+            DayOfMonth = 2,
+            Location = "test-location",
+            DataWarning = true,
+        };
+
+        List<FlaggedBibRecordModel> bibs = new()
+        {
+            alpha, bravo
+        };
+
+        WinlinkMessageModel sut = new()
+        {
+            WinlinkMessageId = "ABC123DEF856",
+            MessageDateStamp = MarchFourth,
+            ClientHostname = "localhost",
+            FileCreatedTimeStamp = JanuarySecond,
+            BibRecords = bibs
+        };
+
+        Assert.True(sut.HasDataWarning());
+    }
+
+    [Fact]
+    public void GetWinlinkMessageInstanceReturnsWinlinkMessageModel()
+    {
+        string winlinkMessageId = "ABC123DEF856";
+        DateTime messageDateTime = MarchFourth;
+        string clientHostname = "localhost";
+        DateTime fileCreatedDateTime = JanuarySecond;
+        List<FlaggedBibRecordModel> bibRecords = new()
+        {
+            new FlaggedBibRecordModel
+            {
+                BibNumber = 1,
+                @Action = "IN",
+                BibTimeOfDay = "1314",
+                DayOfMonth = 2,
+                Location = "test-location",
+                DataWarning = false,
+            }
+        };
+
+        WinlinkMessageModel sut = WinlinkMessageModel.GetWinlinkMessageInstance(winlinkMessageId, messageDateTime, clientHostname, fileCreatedDateTime, bibRecords);
+
+        Assert.NotNull(sut);
+        Assert.Equal(winlinkMessageId, sut.WinlinkMessageId);
+        Assert.Equal(messageDateTime, sut.MessageDateStamp);
+        Assert.Equal(clientHostname, sut.ClientHostname);
+        Assert.Equal(fileCreatedDateTime, sut.FileCreatedTimeStamp);
+        Assert.Single(sut.BibRecords);
+        Assert.Equal(1, sut.BibRecords[0].BibNumber);
     }
 }

--- a/BFBMX.Service.Test/TestData/SampleMessages.cs
+++ b/BFBMX.Service.Test/TestData/SampleMessages.cs
@@ -133,8 +133,7 @@ Content-Type: text/plain; charset=""iso-8859-1""
 Content-Transfer-Encoding: quoted-printable
 
 
------ Message from X0LL was forwarded without change by C4LL at 2023-08-=
-13 19:53 UTC -----
+----- Message from X0LL was forwarded without change by C4LL at 2023-08-13 19:53 UTC -----
 
 Message ID: PIY0NSXF2JJ2
 Date: 2023/08/13 19:52

--- a/BFBMX.Service/Helpers/IFileProcessor.cs
+++ b/BFBMX.Service/Helpers/IFileProcessor.cs
@@ -9,6 +9,7 @@ namespace BFBMX.Service.Helpers
         string GetMessageId(string fileData);
         HashSet<FlaggedBibRecordModel> GetSloppyMatches(string[] lines);
         HashSet<FlaggedBibRecordModel> GetStrictMatches(string[] lines);
+        DateTime GetWinlinkMessageDateTimeStamp(string winlinkMessageData);
         List<FlaggedBibRecordModel> ProcessBibs(string[] lines, string messageId);
         WinlinkMessageModel ProcessWinlinkMessageFile(DateTime timestamp, string machineName, string filePath);
         string RecordsArrayToString(string[] fileData);

--- a/BFBMX.Service/Models/WinlinkMessageModel.cs
+++ b/BFBMX.Service/Models/WinlinkMessageModel.cs
@@ -13,6 +13,15 @@ public class WinlinkMessageModel
     public DateTime FileCreatedTimeStamp { get; set; } // the time the file was created on the Desktop App
     public List<FlaggedBibRecordModel> BibRecords { get; set; } = new List<FlaggedBibRecordModel>();
 
+    /// <summary>
+    /// Guaranteed returns a fully hydrated Winlink Message entity with the provided parameters.
+    /// </summary>
+    /// <param name="winlinkMessageId"></param>
+    /// <param name="messageDateTime"></param>
+    /// <param name="clientHostname"></param>
+    /// <param name="fileCreatedDateTime"></param>
+    /// <param name="bibRecords"></param>
+    /// <returns></returns>
     public static WinlinkMessageModel GetWinlinkMessageInstance(string? winlinkMessageId,
                                                                 DateTime messageDateTime,
                                                                 string? clientHostname,
@@ -29,30 +38,51 @@ public class WinlinkMessageModel
         };
     }
 
+    /// <summary>
+    /// Tests if this Winlink Message entity has any Bib Records with Data Warnings.
+    /// </summary>
+    /// <returns></returns>
     public bool HasDataWarning()
     {
         return BibRecords.Any(x => x.DataWarning);
     }
 
+    /// <summary>
+    /// Generates a printable string representation of the DateTime parameter provided in yyyy-MM-ddTHH-mm-ss format.
+    /// </summary>
+    /// <param name="dateTimeEntry"></param>
+    /// <returns></returns>
     public string PrintableMsgDateTime(DateTime dateTimeEntry)
     {
         return dateTimeEntry.ToString("yyyy-MM-ddTHH-mm-ss");
     }
 
+    /// <summary>
+    /// Converts WinlinkID to a filename for storing a Winlink Message entity to disk.
+    /// </summary>
+    /// <returns>String concatenation of this.WinlinkMessageId with file extension ".txt"</returns>
     public string ToFilename()
     {
         // learn.microsoft.com: 2009-06-15T13:45:30 (DateTimeKind.Local) -> 2009-06-15T13:45:30
         //string customFormatPattern = PrintableMsgDateTime(MessageDateStamp);
-        string customFormatPattern = PrintableMsgDateTime(FileCreatedTimeStamp);
-        return $"{WinlinkMessageId}-{customFormatPattern}.txt";
+        //string customFormatPattern = PrintableMsgDateTime(FileCreatedTimeStamp);
+        return $"{WinlinkMessageId}.txt";
     }
 
+    /// <summary>
+    /// Returns a Json serialized representation of this Winlink Message entity, used for web POSTing and auditing.
+    /// </summary>
+    /// <returns></returns>
     public string ToJsonString()
     {
-        // for sending data over the wire
         return JsonSerializer.Serialize<WinlinkMessageModel>(this);
     }
 
+
+    /// <summary>
+    /// Generate a plain text, tab delimited representation of Bib Records within this Winlink Message entity for consumption by MS Access project.
+    /// </summary>
+    /// <returns></returns>
     public string ToAccessDatabaseTabbedString()
     {
         string recordPrefix = $"{WinlinkMessageId}\t{PrintableMsgDateTime(MessageDateStamp)}\t";
@@ -66,20 +96,11 @@ public class WinlinkMessageModel
         return sbBibData.ToString();
     }
 
-    public string ToServerAuditTabbedString()
-    {
-        string sbHeader = $"{WinlinkMessageId}\t{ClientHostname}\t";
-        StringBuilder sbBibData = new();
-        
-        foreach (var record in BibRecords)
-        {
-            sbBibData.Append(sbHeader).AppendLine(record.ToTabbedString());
-        }
-
-        return sbBibData.ToString();
-    }
-
-    // for sake of comparing entities
+    /// <summary>
+    /// Equals method override used for comparing Winlink Message Entities for equality.
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns></returns>
     public override bool Equals(object? obj)
     {
         if (obj is WinlinkMessageModel other)
@@ -94,7 +115,10 @@ public class WinlinkMessageModel
         return false;
     }
 
-    // for sake of comparing entities
+    /// <summary>
+    /// GetHashCode override used for comparing Winlink Message Entities for equality.
+    /// </summary>
+    /// <returns></returns>
     public override int GetHashCode()
     {
         int hash = 17;

--- a/BFBMX.Service/Models/WinlinkMessageModel.cs
+++ b/BFBMX.Service/Models/WinlinkMessageModel.cs
@@ -8,17 +8,23 @@ public class WinlinkMessageModel
 {
     [Key]
     public string? WinlinkMessageId { get; set; } // max len appears to be 12
-    public DateTime MessageDateTime { get; set; } // datetime from Winlink message
+    public DateTime MessageDateStamp { get; set; } // datetime from Winlink message
     public string? ClientHostname { get; set; } // env:COMPUTERNAME (might not be necessary)
+    public DateTime FileCreatedTimeStamp { get; set; } // the time the file was created on the Desktop App
     public List<FlaggedBibRecordModel> BibRecords { get; set; } = new List<FlaggedBibRecordModel>();
 
-    public static WinlinkMessageModel GetWinlinkMessageInstance(string? winlinkMessageId, DateTime messageDateTime, string? clientHostname, List<FlaggedBibRecordModel> bibRecords)
+    public static WinlinkMessageModel GetWinlinkMessageInstance(string? winlinkMessageId,
+                                                                DateTime messageDateTime,
+                                                                string? clientHostname,
+                                                                DateTime fileCreatedDateTime,
+                                                                List<FlaggedBibRecordModel> bibRecords)
     {
         return new WinlinkMessageModel
         {
             WinlinkMessageId = winlinkMessageId,
-            MessageDateTime = messageDateTime,
+            MessageDateStamp = messageDateTime,
             ClientHostname = clientHostname,
+            FileCreatedTimeStamp = fileCreatedDateTime,
             BibRecords = bibRecords,
         };
     }
@@ -28,15 +34,16 @@ public class WinlinkMessageModel
         return BibRecords.Any(x => x.DataWarning);
     }
 
-    public string PrintableMsgDateTime()
+    public string PrintableMsgDateTime(DateTime dateTimeEntry)
     {
-        return MessageDateTime.ToString("yyyy-MM-ddTHH-mm-ss");
+        return dateTimeEntry.ToString("yyyy-MM-ddTHH-mm-ss");
     }
 
     public string ToFilename()
     {
         // learn.microsoft.com: 2009-06-15T13:45:30 (DateTimeKind.Local) -> 2009-06-15T13:45:30
-        string customFormatPattern = MessageDateTime.ToString("yyyy-MM-ddTHH-mm-ss");
+        //string customFormatPattern = PrintableMsgDateTime(MessageDateStamp);
+        string customFormatPattern = PrintableMsgDateTime(FileCreatedTimeStamp);
         return $"{WinlinkMessageId}-{customFormatPattern}.txt";
     }
 
@@ -48,7 +55,7 @@ public class WinlinkMessageModel
 
     public string ToAccessDatabaseTabbedString()
     {
-        string recordPrefix = $"{WinlinkMessageId}\t{PrintableMsgDateTime()}\t";
+        string recordPrefix = $"{WinlinkMessageId}\t{PrintableMsgDateTime(MessageDateStamp)}\t";
         StringBuilder sbBibData = new();
 
         foreach(var record in BibRecords)
@@ -78,8 +85,9 @@ public class WinlinkMessageModel
         if (obj is WinlinkMessageModel other)
         {
             return WinlinkMessageId == other.WinlinkMessageId
-                && MessageDateTime == other.MessageDateTime
+                && MessageDateStamp == other.MessageDateStamp
                 && ClientHostname == other.ClientHostname
+                && FileCreatedTimeStamp == other.FileCreatedTimeStamp
                 && (BibRecords?.Count == other.BibRecords?.Count);
         }
 
@@ -91,8 +99,9 @@ public class WinlinkMessageModel
     {
         int hash = 17;
         hash = hash * 23 + (WinlinkMessageId?.GetHashCode() ?? 0);
-        hash = hash * 23 + MessageDateTime.GetHashCode();
+        hash = hash * 23 + MessageDateStamp.GetHashCode();
         hash = hash * 23 + (ClientHostname?.GetHashCode() ?? 0);
+        hash = hash * 23 + FileCreatedTimeStamp.GetHashCode();
         hash = hash * 23 + (BibRecords?.Count.GetHashCode() ?? 0);
         return hash;
     }


### PR DESCRIPTION
This PR contains potential updates to the Winlink Message model, tests, and logging output, that support tracking Winlink Message timestamp AND file creation timestamp, from end to end.

The hope is having both available in logs and backup data will improve ability to rapidly audit data consistency on the clients' side and server side.