### PR TITLE
Update matching to allow comma-delimiters

### DIFF
--- a/BFBMX.Service.Test/Helpers/FileProcessorTests.cs
+++ b/BFBMX.Service.Test/Helpers/FileProcessorTests.cs
@@ -65,33 +65,63 @@ public class FileProcessorTests
     }
 
     [Fact]
-    public void CaptureThreeBibRecordsStrict()
+    public void CaptureThreeBibRecordsTabsStrict()
     {
         int expectedCount = 3;
-        var bibList = new string[] {
+        var bibListTabs = new string[] {
           "115\tOUT\t2009\t11\tWR",
           "195\tOUT\t2009\t11\tWR",
           "196\tOUT\t2009\t11\tWR"
         };
 
-        List<FlaggedBibRecordModel> actualResult = _fileProcessor.GetStrictMatches(bibList).ToList();
+        List<FlaggedBibRecordModel> actualResult = _fileProcessor.GetStrictMatches(bibListTabs).ToList();
         Assert.NotNull(actualResult);
         Assert.Equal(expectedCount, actualResult.Count);
     }
 
     [Fact]
-    public void CaptureThreeBibRecordsNotStrict()
+    public void CaptureThreeBibRecordsCommasStrict()
+    {  
+        int expectedCount = 3;
+        var bibListCommas = new string[] {
+          "115,OUT,2009,11,WR",
+          "195,OUT,2009,11,WR",
+          "196,OUT,2009,11,WR"
+        };
+
+        List<FlaggedBibRecordModel> actualCommaDelmitedResult = _fileProcessor.GetStrictMatches(bibListCommas).ToList();
+        Assert.NotNull(actualCommaDelmitedResult);
+        Assert.Equal(expectedCount, actualCommaDelmitedResult.Count);
+    }
+
+    [Fact]
+    public void CaptureThreeBibRecordsTabsSloppy()
     {
-        int expectedCount = 2;
-        var bibList = new string[] {
+        int expectedCount = 3;
+        var bibListTabs = new string[] {
           "115	0UT	2oo9	II	WR",
           "195	OUT	2009	11	WR",
           "196	OUT	2009	11	WR"
         };
 
-        List<FlaggedBibRecordModel> actualResult = _fileProcessor.GetStrictMatches(bibList).ToList();
-        Assert.NotNull(actualResult);
-        Assert.Equal(expectedCount, actualResult.Count);
+        List<FlaggedBibRecordModel> actualTabDelimitedResult = _fileProcessor.GetSloppyMatches(bibListTabs).ToList();
+        Assert.NotNull(actualTabDelimitedResult);
+        Assert.Equal(expectedCount, actualTabDelimitedResult.Count);
+    }
+
+    [Fact]
+    public void CaptureThreeBibRecordsCommasSloppy()
+    {
+        int expectedCount = 3;
+        var bibListCommas = new string[] {
+          "115 , 0UT,2oo9, II ,WR",
+          "195,OUT,2009,11,WR",
+          "196, OUT ,2009 , 11,  WR"
+        };
+
+        List<FlaggedBibRecordModel> actualCommaDelimitedResult = _fileProcessor.GetSloppyMatches(bibListCommas).ToList();
+        Assert.NotNull(actualCommaDelimitedResult);
+        Assert.Equal(expectedCount, actualCommaDelimitedResult.Count);
     }
 
     [Fact]
@@ -209,17 +239,20 @@ public class FileProcessorTests
     }
 
     [Fact]
-    public void MatchersFailToMatchCommaDelimintedBibsInValidMessage()
+    public void MatchersMatchCommaDelimintedBibs_ValidMessage()
     {
-        string commaDelimitedMessages = SampleMessages.ValidMessageWithCommaDelimintedBibs;
-        int expectedCommaDelimitedBibs = 0; // there are 5 comma-delimited bibs in the sample msg
+        string commaDelimitedMessages = SampleMessages.ValidMessageWithCommaDelimitedBibs;
+
+        // there are 5 comma-delimited bibs in the sample msg
+        int expectedStrictCount = 1;
+        int expectedLooseCount = 5;
         string[] commaDelimitedLines = commaDelimitedMessages.Split('\n');
 
         List<FlaggedBibRecordModel> actualStrictResult = _fileProcessor.GetStrictMatches(commaDelimitedLines).ToList();
         List<FlaggedBibRecordModel> actualSloppyResultList = _fileProcessor.GetSloppyMatches(commaDelimitedLines).ToList();
 
-        Assert.Equal(expectedCommaDelimitedBibs, actualStrictResult.Count);
-        Assert.Equal(expectedCommaDelimitedBibs, actualSloppyResultList.Count);
+        Assert.Equal(expectedStrictCount, actualStrictResult.Count);
+        Assert.Equal(expectedLooseCount, actualSloppyResultList.Count);
     }
 
     [Fact]
@@ -351,7 +384,7 @@ public class FileProcessorTests
     }
 
     [Fact]
-    public void ProcessBibs_ProcessesBibsSuccessfully()
+    public void ProcessBibs_ProcessesTabDelimBibsSuccessfully()
     {
         // Arrange
         int expectedCount = 5;
@@ -378,6 +411,36 @@ public class FileProcessorTests
         Assert.NotEmpty(bibRecords);
         Assert.Equal(expectedCount, bibRecords.Count);
     }
+
+    [Fact]
+    public void ProcessBibs_ProcessesCommaDelimBibsSuccessfully()
+    {
+        // Arrange
+        int expectedCount = 5;
+        List<FlaggedBibRecordModel> bibRecords = new();
+        string messageId = "ABC123DEF456";
+
+        var lines = new string[] {
+        "Content-Transfer-Encoding: quoted - printable",
+        "",
+        "-",
+        "10,OUT,834,13,CH",
+        "10,IN,748,13,CH",
+        "34,OUT,449,13,CH",
+        "34,IN,406,13,CH",
+        "37,OUT,855,13,CH",
+        "-----",
+        "* The entries in this email are TAB delimited. This allows you to copy and =\r\npaste into a spreadsheet."
+        };
+
+        // Act
+        bibRecords = _fileProcessor.ProcessBibs(lines, messageId);
+
+        // Assert
+        Assert.NotEmpty(bibRecords);
+        Assert.Equal(expectedCount, bibRecords.Count);
+    }
+
     [Fact]
     public void FileProcessor_ProcessBibLikeMessageContentShouldFindNone()
     {

--- a/BFBMX.Service.Test/TestData/SampleMessages.cs
+++ b/BFBMX.Service.Test/TestData/SampleMessages.cs
@@ -222,8 +222,7 @@ Template version 1.1.7
 --boundaryOTJvbw==--
 ";
 
-        public static string ValidMessageWith5SpaceDelimitedBibs => @"
-        public static string MessageWith26ValidBibs => @""Date: Mon, 14 Aug 2023 01:25:57 +0000
+        public static string ValidMessageWith5SpaceDelimitedBibs => @"Date: Mon, 14 Aug 2023 01:25:57 +0000
 From: C4LL@winlink.org
 Reply-To: C4LL@winlink.org
 Subject: Bigfoot 200 2023 Chain of Lakes Message #4
@@ -256,11 +255,9 @@ Winlink Express Sender C4LL=20
 Template version 1.1.7
 
 --boundaryOTJvbw==--
-"";
 ";
 
-        public static string ValidMessageWithCommaDelimintedBibs => @"        public static string ValidMessageWith5SpaceDelimitedBibs => @""
-        public static string MessageWith26ValidBibs => @""""Date: Mon, 14 Aug 2023 01:25:57 +0000
+        public static string ValidMessageWithCommaDelimitedBibs => @"Date: Mon, 14 Aug 2023 01:25:57 +0000
 From: C4LL@winlink.org
 Reply-To: C4LL@winlink.org
 Subject: Bigfoot 200 2023 Chain of Lakes Message #4
@@ -271,10 +268,10 @@ X-Source: C4LL
 X-Location: 46.293940N, 121.594845W (GPS)
 MIME-Version: 1.0
 MIME-Version: 1.0
-Content-Type: multipart/mixed; boundary=""""""""boundaryOTJvbw==""""""""
+Content-Type: multipart/mixed; boundary=""""boundaryOTJvbw==""""
 
 --boundaryOTJvbw==
-Content-Type: text/plain; charset=""""""""iso-8859-1""""""""
+Content-Type: text/plain; charset=""""iso-8859-1""""
 Content-Transfer-Encoding: quoted-printable
 
 -
@@ -293,8 +290,6 @@ Winlink Express Sender C4LL=20
 Template version 1.1.7
 
 --boundaryOTJvbw==--
-"""";
-"";
 ";
     }
 }

--- a/BFBMX.Service/Helpers/FileProcessor.cs
+++ b/BFBMX.Service/Helpers/FileProcessor.cs
@@ -13,8 +13,8 @@ namespace BFBMX.Service.Helpers
         private readonly ILogger<FileProcessor> _logger;
 
         private readonly string messageIdPattern = @"\bMessage-ID\S\s?(?'msgid'.{12})\b";
-        private readonly string strictBibPatternTabDelim = @"\b\d{1,3}\t(OUT|IN|DROP)\t\d{1,4}\t\d{1,2}\t\w{2}\b";
-        private readonly string sloppyBibPatternTabDelim = @"\b\w{1,15}\t\w{1,5}\t\w{1,5}\t\w{1,3}\t\w{1,26}\b";
+        private readonly string strictBibPattern = @"\b\d{1,3}[,|\t](OUT|IN|DROP)[,|\t]\d{1,4}[,|\t]\d{1,2}[,|\t]\w{2}\b";
+        private readonly string sloppyBibPattern = @"\b\w{1,26}(?:\s*[,|\t]\s*\w{1,26}){4}\b";
 
         public FileProcessor(ILogger<FileProcessor> logger)
         {
@@ -226,18 +226,14 @@ namespace BFBMX.Service.Helpers
         /// <returns>List of FlaggedBibRecordModel instances</returns>
         public HashSet<FlaggedBibRecordModel> GetSloppyMatches(string[] lines)
         {
+            HashSet<FlaggedBibRecordModel> foundBibRecords = new();
+
             if (lines is null || lines.Length < 1)
             {
-                return new HashSet<FlaggedBibRecordModel>();
+                return foundBibRecords;
             }
 
-            HashSet<FlaggedBibRecordModel> foundBibRecords = GetBibMatches(lines, sloppyBibPatternTabDelim);
-
-            foreach(FlaggedBibRecordModel bibRecord in foundBibRecords)
-            {
-                bibRecord.DataWarning = true;
-            }
-
+            foundBibRecords = GetBibMatches(lines, sloppyBibPattern, true);
             return foundBibRecords;
         }
 
@@ -248,59 +244,72 @@ namespace BFBMX.Service.Helpers
         /// <returns>List of FlaggedBibRecordModel instances</returns>
         public HashSet<FlaggedBibRecordModel> GetStrictMatches(string[] lines)
         {
+            HashSet<FlaggedBibRecordModel> foundBibRecords = new();
+
             if (lines is null || lines.Length < 1)
             {
-                return new HashSet<FlaggedBibRecordModel>();
+                return foundBibRecords;
             }
 
-            return GetBibMatches(lines, strictBibPatternTabDelim);
+            foundBibRecords = GetBibMatches(lines, strictBibPattern, false);
+            return foundBibRecords;
         }
 
         /// <summary>
-        /// Identifies data matches in array of potential bib records usinga RegEx pattern.
-        /// Data Warning flags could be set on any FlaggedBibRecordModel that cannot be fully parsed.
+        /// Identifies data matches in an array of potential bib records using a 
+        /// strict RegEx pattern that follows the BibFoot Bib Report Form format.
         /// </summary>
-        /// <param name="emptyBibList"></param>
         /// <param name="fileDataLines"></param>
         /// <param name="pattern"></param>
-        /// <returns>true if any matches are found, false in any other case.</returns>
-        public HashSet<FlaggedBibRecordModel> GetBibMatches(string[] fileDataLines, string pattern)
+        /// <returns></returns>
+        public HashSet<FlaggedBibRecordModel> GetBibMatches(string[] fileDataLines,
+                                                               string pattern,
+                                                               bool setWarning = false)
         {
-            HashSet<FlaggedBibRecordModel> emptyBibList = new();
+            HashSet<FlaggedBibRecordModel> resultBibList = new();
 
-            if (
-                fileDataLines is null || fileDataLines.Length < 1
-                || string.IsNullOrWhiteSpace(pattern)
-                )
+            if (fileDataLines is null || fileDataLines.Length < 1 || string.IsNullOrWhiteSpace(pattern))
             {
-                return emptyBibList;
+                return resultBibList;
             }
             else
             {
+                Regex regex = new(pattern, RegexOptions.IgnoreCase, new TimeSpan(0, 0, 2));
+
                 foreach (var line in fileDataLines)
                 {
-                    try
-                    {
-                        if (Regex.IsMatch(line, pattern, RegexOptions.IgnoreCase, new TimeSpan(0, 0, 2)))
-                        {
-                            var fields = line.Split('\t');
-                            FlaggedBibRecordModel bibRecord = FlaggedBibRecordModel.GetBibRecordInstance(fields);
+                    var fields = line.Split('\t', ',');
 
-                            if (bibRecord is not null)
+                    if (fields.Length == 5)
+                    {
+                        try
+                        {
+                            if (regex.IsMatch(line))
+
                             {
-                                emptyBibList.Add(bibRecord);
+                                FlaggedBibRecordModel bibRecord = FlaggedBibRecordModel.GetBibRecordInstance(fields);
+
+                                if (bibRecord is not null)
+                                {
+                                    if (setWarning)
+                                    {
+                                        bibRecord.DataWarning = true;
+                                    }
+
+                                    resultBibList.Add(bibRecord);
+                                }
                             }
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError("FileProcessor GetBibMatches: RegEx operation could not match {pattern} to {line}!", pattern, line);
-                        _logger.LogError("FileProcessor GetBibMatches: Exception message is {exMessage}.", ex.Message);
-                        _logger.LogError("FileProcessor GetBibMatches: Operations will continue but an audit should be performed.");
+                        catch (Exception ex)
+                        {
+                            _logger.LogError("FileProcessor GetBibMatches: RegEx operation could not match {pattern} to {line}!", pattern, line);
+                            _logger.LogError("FileProcessor GetBibMatches: Exception message is {exMessage}.", ex.Message);
+                            _logger.LogError("FileProcessor GetBibMatches: Operations will continue but an audit should be performed.");
+                        }
                     }
                 }
 
-                return emptyBibList;
+                return resultBibList;
             }
         }
     }

--- a/BFBMX.Service/Helpers/IFileProcessor.cs
+++ b/BFBMX.Service/Helpers/IFileProcessor.cs
@@ -4,7 +4,7 @@ namespace BFBMX.Service.Helpers
 {
     public interface IFileProcessor
     {
-        HashSet<FlaggedBibRecordModel> GetBibMatches(string[] fileDataLines, string pattern);
+        HashSet<FlaggedBibRecordModel> GetBibMatches(string[] fileDataLines, string pattern, bool flag=false);
         string[] GetFileData(string fullFilePath);
         string GetMessageId(string fileData);
         HashSet<FlaggedBibRecordModel> GetSloppyMatches(string[] lines);


### PR DESCRIPTION
- [x] Add comma-separated patterns to strict and loose matchers.
- [x] Update field-length limitations to 1-26 characters to catch possible data warning cases.
- [x] Update tests for new, existing functionality.
