### PR TITLE
Dev early morning time format

### DIFF
--- a/BFBMX.Service.Test/Models/BibRecordModelsTests.cs
+++ b/BFBMX.Service.Test/Models/BibRecordModelsTests.cs
@@ -259,6 +259,121 @@ namespace BFBMX.Service.Test.Models
         }
 
         [Fact]
+        public void BibTimeFieldSingleCharacterLeftPadsWith3Zeros()
+        {
+            // arrange
+            string expectedResult = "NOMINAL\t1\tIN\t0001\t2\tTL";
+
+            FlaggedBibRecordModel bibEntry = new()
+            {
+                BibNumber = 1,
+                Action = "IN",
+                BibTimeOfDay = "1",
+                DayOfMonth = 2,
+                Location = "TL",
+                DataWarning = false
+            };
+
+            // act
+            string actualResult = bibEntry.ToTabbedString();
+
+            // assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void BibTimeFieldTenMintuesCharactersLeftPadsWith2Zeros()
+        {
+            // arrange
+            string expectedResult = "NOMINAL\t1\tIN\t0010\t2\tTL";
+
+            FlaggedBibRecordModel bibEntry = new()
+            {
+                BibNumber = 1,
+                Action = "IN",
+                BibTimeOfDay = "10",
+                DayOfMonth = 2,
+                Location = "TL",
+                DataWarning = false
+            };
+
+            // act
+            string actualResult = bibEntry.ToTabbedString();
+
+            // assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void BibTimeFieldSingleHoursCharacterLeftPadsWith1Zero()
+        {
+            // arrange
+            string expectedResult = "NOMINAL\t1\tIN\t0100\t2\tTL";
+
+            FlaggedBibRecordModel bibEntry = new()
+            {
+                BibNumber = 1,
+                Action = "IN",
+                BibTimeOfDay = "100",
+                DayOfMonth = 2,
+                Location = "TL",
+                DataWarning = false
+            };
+
+            // act
+            string actualResult = bibEntry.ToTabbedString();
+
+            // assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void BibTimeFieldTensHoursCharacterNotPadded()
+        {
+            // arrange
+            string expectedResult = "NOMINAL\t1\tIN\t1000\t2\tTL";
+
+            FlaggedBibRecordModel bibEntry = new()
+            {
+                BibNumber = 1,
+                Action = "IN",
+                BibTimeOfDay = "1000",
+                DayOfMonth = 2,
+                Location = "TL",
+                DataWarning = false
+            };
+
+            // act
+            string actualResult = bibEntry.ToTabbedString();
+
+            // assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void BibTimeFieldFiveCharacterTimeNotPadded()
+        {
+            // arrange
+            string expectedResult = "ALERT\t1\tIN\t11000\t2\tTL";
+
+            FlaggedBibRecordModel bibEntry = new()
+            {
+                BibNumber = 1,
+                Action = "IN",
+                BibTimeOfDay = "11000",
+                DayOfMonth = 2,
+                Location = "TL",
+                DataWarning = true
+            };
+
+            // act
+            string actualResult = bibEntry.ToTabbedString();
+
+            // assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
         public void SloppyBibTime27Characters()
         {
             // note: the Matcher methods have the character limit restriction

--- a/BFBMX.Service.Test/Models/BibRecordModelsTests.cs
+++ b/BFBMX.Service.Test/Models/BibRecordModelsTests.cs
@@ -188,5 +188,99 @@ namespace BFBMX.Service.Test.Models
 
             Assert.Equal(expectedWarningData, actualWarningData);
         }
+
+        [Fact]
+        public void ZeroHundredHourBibTimeIncludesLeadingZeros()
+        {
+            // arrange
+            string expectedResult = "NOMINAL\t1\tIN\t0001\t2\tTL";
+
+            FlaggedBibRecordModel bibEntry = new()
+            {
+                BibNumber = 1,
+                Action = "IN",
+                BibTimeOfDay = "0001",
+                DayOfMonth = 2,
+                Location = "TL",
+                DataWarning = false
+            };
+
+            // act
+            string actualResult = bibEntry.ToTabbedString();
+
+            // assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void ZeroHundredTenHourBibTimeIncludesLeadingZeros()
+        {
+            // arrange
+            string expectedResult = "NOMINAL\t1\tIN\t0010\t2\tTL";
+
+            FlaggedBibRecordModel bibEntry = new()
+            {
+                BibNumber = 1,
+                Action = "IN",
+                BibTimeOfDay = "0010",
+                DayOfMonth = 2,
+                Location = "TL",
+                DataWarning = false
+            };
+
+            // act
+            string actualResult = bibEntry.ToTabbedString();
+
+            // assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void SloppyBibTimeIncludesLeadingZeros()
+        {
+            // arrange
+            string expectedResult = "ALERT\t1\tIN\t0E01\t2\tTL";
+
+            FlaggedBibRecordModel bibEntry = new()
+            {
+                BibNumber = 1,
+                Action = "IN",
+                BibTimeOfDay = "0E01",
+                DayOfMonth = 2,
+                Location = "TL",
+                DataWarning = true
+            };
+
+            // act
+            string actualResult = bibEntry.ToTabbedString();
+
+            // assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void SloppyBibTime27Characters()
+        {
+            // note: the Matcher methods have the character limit restriction
+            // arrange
+            string expectedResult = "ALERT\t1\tIN\t0123456789ABCDEFGHIJ123456\t2\tTL";
+
+            FlaggedBibRecordModel bibEntry = new()
+            {
+                BibNumber = 1,
+                Action = "IN",
+                BibTimeOfDay = "0123456789ABCDEFGHIJ123456",
+                DayOfMonth = 2,
+                Location = "TL",
+                DataWarning = true
+            };
+
+            // act
+            string actualResult = bibEntry.ToTabbedString();
+
+            // assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+
     }
 }

--- a/BFBMX.Service.Test/Models/WinlinkMessageModelTests.cs
+++ b/BFBMX.Service.Test/Models/WinlinkMessageModelTests.cs
@@ -259,7 +259,7 @@ public class WinlinkMessageModelTests
     }
 
     [Fact]
-    public void MessageToStringWithWarning()
+    public void MessageToServerAuditTabbedWithWarning()
     {
         var bibEntry = new FlaggedBibRecordModel
         {

--- a/BFBMX.Service/Models/FlaggedBibRecordModel.cs
+++ b/BFBMX.Service/Models/FlaggedBibRecordModel.cs
@@ -79,7 +79,8 @@ namespace BFBMX.Service.Models
         {
             // Set DataWarning as a string: ALERT if true, NOMINAL if false
             string dwText = DataWarning ? "ALERT" : "NOMINAL";
-            return $"{dwText}\t{BibNumber}\t{Action}\t{BibTimeOfDay}\t{DayOfMonth}\t{Location}";
+            string? paddedBibTime = BibTimeOfDay?.Length < 4 ? BibTimeOfDay.PadLeft(4, '0') : BibTimeOfDay;
+            return $"{dwText}\t{BibNumber}\t{Action}\t{paddedBibTime}\t{DayOfMonth}\t{Location}";
         }
 
         public string ToJsonString()


### PR DESCRIPTION
- [x] Ensure stringified bib records include a leading zero when 24-hour time is less than 1000 (10 am).
- [x] Time inputs of 4 or more characters are not padded.
- [x] Add, update unit tests.
