### PR TITLE
Dev server logs ip port

### DIFF
--- a/BFBMX.ServerApi/Helpers/IServerEnvFactory.cs
+++ b/BFBMX.ServerApi/Helpers/IServerEnvFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace BFBMX.ServerApi.Helpers
+﻿using System.Net;
+
+namespace BFBMX.ServerApi.Helpers
 {
     public interface IServerEnvFactory
     {
@@ -7,5 +9,7 @@
         string GetServerFolderName();
         string GetServerLogPath();
         string GetUserProfilePath();
+        string GetServerPort();
+        IPHostEntry GetServerHostname();
     }
 }

--- a/BFBMX.ServerApi/Helpers/IServerInfo.cs
+++ b/BFBMX.ServerApi/Helpers/IServerInfo.cs
@@ -1,0 +1,9 @@
+﻿
+namespace BFBMX.ServerApi.Helpers
+{
+    public interface IServerInfo
+    {
+        bool CanStart();
+        void Start();
+    }
+}

--- a/BFBMX.ServerApi/Helpers/IServerInfo.cs
+++ b/BFBMX.ServerApi/Helpers/IServerInfo.cs
@@ -4,6 +4,7 @@ namespace BFBMX.ServerApi.Helpers
     public interface IServerInfo
     {
         bool CanStart();
-        void Start();
+        void StartHostInfo();
+        void StartLogfileInfo();
     }
 }

--- a/BFBMX.ServerApi/Helpers/ServerEnvFactory.cs
+++ b/BFBMX.ServerApi/Helpers/ServerEnvFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace BFBMX.ServerApi.Helpers
+﻿using System.Net;
+
+namespace BFBMX.ServerApi.Helpers
 {
     public class ServerEnvFactory : IServerEnvFactory
     {
@@ -38,6 +40,18 @@
                 GetServerBackupFilename()
                 );
             return backupFilePathAndName;
+        }
+
+        public string GetServerPort()
+        {
+            return Environment.GetEnvironmentVariable("BFBMX_SERVERPORT") ?? "5150";
+        }
+
+        public IPHostEntry GetServerHostname()
+        {
+            string serverName = Dns.GetHostName();
+            IPHostEntry hostEntryName = Dns.GetHostEntry(serverName);
+            return hostEntryName;
         }
     }
 }

--- a/BFBMX.ServerApi/Helpers/ServerInfo.cs
+++ b/BFBMX.ServerApi/Helpers/ServerInfo.cs
@@ -1,0 +1,51 @@
+﻿using System.Net.Sockets;
+using System.Net;
+
+namespace BFBMX.ServerApi.Helpers
+{
+    public class ServerInfo : IServerInfo
+    {
+        private readonly ILogger<ServerInfo> _logger;
+        private readonly IServerEnvFactory _serverEnvFactory;
+        private DateTime _executionTime;
+        private TimeSpan _offset = new(0, 10, 0); // 10 minutes
+
+        public ServerInfo(ILogger<ServerInfo> logger, IServerEnvFactory serverEnvFactory)
+        {
+            _logger = logger;
+            _serverEnvFactory = serverEnvFactory;
+            _executionTime = DateTime.Now;
+        }
+
+        public bool CanStart()
+        {
+            return DateTime.Now - _executionTime > _offset;
+        }
+
+        public void Start()
+        {
+            _executionTime = DateTime.Now;
+
+                // get current hostname, ipaddress, and configured port
+                string serverPort = _serverEnvFactory.GetServerPort();
+                IPHostEntry hostEntry = _serverEnvFactory.GetServerHostname();
+                string machineName = hostEntry.HostName;
+                string ipV4Addresses = string.Empty;
+
+                foreach (IPAddress ipAddr in hostEntry.AddressList)
+                {
+                    if (!ipAddr.AddressFamily.ToString().Equals(ProtocolFamily.InterNetworkV6.ToString()))
+                    {
+                        if (ipV4Addresses.Length > 0)
+                        {
+                            ipV4Addresses += ", ";
+                        }
+
+                        ipV4Addresses += ipAddr.ToString();
+                    }
+                }
+
+                _logger.LogInformation("Server name {machinename} at address(es) {ipv4addresses} listening on HTTP port {serverport}", machineName, ipV4Addresses, serverPort);
+        }
+    }
+}

--- a/BFBMX.ServerApi/Helpers/ServerInfo.cs
+++ b/BFBMX.ServerApi/Helpers/ServerInfo.cs
@@ -8,7 +8,7 @@ namespace BFBMX.ServerApi.Helpers
         private readonly ILogger<ServerInfo> _logger;
         private readonly IServerEnvFactory _serverEnvFactory;
         private DateTime _executionTime;
-        private TimeSpan _offset = new(0, 10, 0); // 10 minutes
+        private TimeSpan _minWaitTime = new(0, 15, 0); // 10 minutes
 
         public ServerInfo(ILogger<ServerInfo> logger, IServerEnvFactory serverEnvFactory)
         {
@@ -17,35 +17,50 @@ namespace BFBMX.ServerApi.Helpers
             _executionTime = DateTime.Now;
         }
 
+        /// <summary>
+        /// Returns true if the minimum wait time has passed since the last execution.
+        /// </summary>
+        /// <returns>True if minimum wait time has passed since last exectuion.</returns>
         public bool CanStart()
         {
-            return DateTime.Now - _executionTime > _offset;
+            return DateTime.Now - _executionTime > _minWaitTime;
         }
 
-        public void Start()
+        /// <summary>
+        /// Logs configured Hostname, IP address(es), and HTTP listen port to the console.
+        /// </summary>
+        public void StartHostInfo()
         {
             _executionTime = DateTime.Now;
+            string serverPort = _serverEnvFactory.GetServerPort();
+            IPHostEntry hostEntry = _serverEnvFactory.GetServerHostname();
+            string machineName = hostEntry.HostName;
+            string ipV4Addresses = string.Empty;
 
-                // get current hostname, ipaddress, and configured port
-                string serverPort = _serverEnvFactory.GetServerPort();
-                IPHostEntry hostEntry = _serverEnvFactory.GetServerHostname();
-                string machineName = hostEntry.HostName;
-                string ipV4Addresses = string.Empty;
-
-                foreach (IPAddress ipAddr in hostEntry.AddressList)
+            foreach (IPAddress ipAddr in hostEntry.AddressList)
+            {
+                if (!ipAddr.AddressFamily.ToString().Equals(ProtocolFamily.InterNetworkV6.ToString()))
                 {
-                    if (!ipAddr.AddressFamily.ToString().Equals(ProtocolFamily.InterNetworkV6.ToString()))
+                    if (ipV4Addresses.Length > 0)
                     {
-                        if (ipV4Addresses.Length > 0)
-                        {
-                            ipV4Addresses += ", ";
-                        }
-
-                        ipV4Addresses += ipAddr.ToString();
+                        ipV4Addresses += ", ";
                     }
-                }
 
-                _logger.LogInformation("Server name {machinename} at address(es) {ipv4addresses} listening on HTTP port {serverport}", machineName, ipV4Addresses, serverPort);
+                    ipV4Addresses += ipAddr.ToString();
+                }
+            }
+
+            _logger.LogInformation("Server name {machinename} at address(es) {ipv4addresses} listening on HTTP port {serverport}", machineName, ipV4Addresses, serverPort);
+        }
+
+        /// <summary>
+        /// Logs configured location of server log files to the console.
+        /// </summary>
+        public void StartLogfileInfo()
+        {
+            _executionTime = DateTime.Now;
+            string configuredLogFilepath = _serverEnvFactory.GetServerLogPath();
+            _logger.LogInformation("Logfiles are at {configuredlogfilepath}", configuredLogFilepath);
         }
     }
 }

--- a/BFBMX.ServerApi/Program.cs
+++ b/BFBMX.ServerApi/Program.cs
@@ -58,9 +58,15 @@ if (app.Environment.IsDevelopment())
 // supports logging HTTP Requests and Responses
 app.UseHttpLogging();
 
+serverInfo.StartLogfileInfo();
+
 app.MapGet("/serverInfo", () =>
 {
-    serverInfo.Start();
+    if (serverInfo.CanStart())
+    {
+        serverInfo.StartHostInfo();
+        serverInfo.StartLogfileInfo();
+    }
 }).Produces(200).ProducesProblem(500);
 
 app.MapPost("/WinlinkMessage", (WinlinkMessageModel request) =>
@@ -87,7 +93,7 @@ app.MapPost("/WinlinkMessage", (WinlinkMessageModel request) =>
 
     if (serverInfo.CanStart())
     {
-        serverInfo.Start();
+        serverInfo.StartHostInfo();
     }
 
     // return 200 OK or 400 Bad Request

--- a/BFBMX.Service.Test/Helpers/ServerEnvFactoryTests.cs
+++ b/BFBMX.Service.Test/Helpers/ServerEnvFactoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using BFBMX.ServerApi.Helpers;
+using System.Net;
 
 namespace BFBMX.Service.Test.Helpers
 {
@@ -9,6 +10,21 @@ namespace BFBMX.Service.Test.Helpers
         public ServerEnvFactoryTests()
         {
             _serverEnvFactory = new ServerEnvFactory();
+        }
+
+        [Fact]
+        public void GetHostnameSucceeds()
+        {
+            string hostname = Dns.GetHostName();
+            IPHostEntry actualHostEntry = _serverEnvFactory.GetServerHostname();
+            Assert.Equal(hostname, actualHostEntry.HostName);
+        }
+
+        [Fact]
+        public void GetPortSucceeds()
+        {
+            string bfbmxPort = Environment.GetEnvironmentVariable("BFBMX_SERVERPORT") ?? "5150";
+            Assert.Equal(bfbmxPort, _serverEnvFactory.GetServerPort());
         }
 
         [Fact]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The overarching goal of this project is to create a synchronization tool that wi
 
 ## Project Status
 
+27-Apr-2024:
+
+- Server now logs detected local IP Addresses and Port to the console output.
+
 20-Apr-2024:
 
 - Added support to detect comma-separated values in the BibRecord data.
@@ -275,6 +279,7 @@ The Console Window:
 - Use the scroll bar or a mouse wheel to scroll up and down the console window to review past activities.
 - The console window can be changed in size to fit your needs without interrupting the server service in any way.
 - Most information written to the console window will be informational, but warnings and errors will be highlighted in yellow and red, respectively.
+- Occasional log entries will display the server Hostname, IP Address(es), and HTTP Port.
 
 The Log Files:
 


### PR DESCRIPTION
A Desktop App operator will need the server name or IP address, and HTTP Port to configure environment variables so Desktop App can send messages to the server. Enable the Server Operator to acquire this information quickly and easily.

- [x] Add ability to log server IPAddress.
- [x] Add ability to log server HTTP Port.
- [x] Add ability to log server Hostname.
- [x] Add ability to log configured path to server log files.
- [x] Add unit tests to changed and new code.
