### PR TITLE
Fix Desktop Logger DateTime Stamps

### DIFF
--- a/BFBMX.Desktop/Helpers/DesktopLogger.cs
+++ b/BFBMX.Desktop/Helpers/DesktopLogger.cs
@@ -10,11 +10,9 @@ namespace BFBMX.Desktop.Helpers
     {
         private static readonly object _lock = new object();
         private readonly Func<DesktopLoggerConfiguration> getCurrentConfig;
-        private readonly string? name;
 
-        public DesktopLogger(string name, Func<DesktopLoggerConfiguration> getCurrentConfig)
+        public DesktopLogger(Func<DesktopLoggerConfiguration> getCurrentConfig)
         {
-            this.name = name;
             this.getCurrentConfig = getCurrentConfig;
         }
 
@@ -49,7 +47,7 @@ namespace BFBMX.Desktop.Helpers
                 {
                     string message = formatter(state, exception);
                     DateTime timeStamp = DateTime.Now;
-                    string concatMessage = $"{timeStamp:dd-MM-yy-HH:mm:ss} {logLevelText}: {message}";
+                    string concatMessage = $"{timeStamp:yyyy-MMM-dd HH:mm:ss} {logLevelText}: {message}";
                     string filePath = config.LogfilePath!;
 
                     lock (_lock)
@@ -102,7 +100,7 @@ namespace BFBMX.Desktop.Helpers
         {
             return _loggers.GetOrAdd(
                 categoryName,
-                name => new DesktopLogger(categoryName, GetCurrentConfig));
+                name => new DesktopLogger(GetCurrentConfig));
         }
 
         private DesktopLoggerConfiguration GetCurrentConfig()

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The overarching goal of this project is to create a synchronization tool that wi
 
 ## Project Status
 
+26-Apr-2024:
+
+- Changed Desktop Logging format from `dd-MM-yy-HH:mm:ss` (27-04-24-16:42:23) to `yyyy-MMM-dd HH:mm:ss` (2024-Apr-27 16:42:23), improving readability.
+
 20-Apr-2024:
 
 - Added support to detect comma-separated values in the BibRecord data.
@@ -236,6 +240,7 @@ BFBMX Desktop App Log:
 - The activities log are stored in a file named `bfbmx-desktop-app-log.txt`.
 - Button clicks, discovered files, and discovered data events are all recorded in this log.
 - A plain text file and can be opened with any text editor.
+- The data format is: `yyyy-MMM-dd HH:mm:ss [INFO|WARN|ERROR]: {Module Member Name}: (a plain english explanation of Desktop Action or state information).`.
 
 Captured Bib Records:
 


### PR DESCRIPTION
The Desktop Logger writes a date-time stamp to all log entries. The format is a little hard to read, being all numbers and dashes.

- [x] Change Desktop Logger date-time format so it is more easily readable at a glance.
- [x] Update README.
