### PR TITLE
Open Logfile Path from Desktop UI

### DIFF
--- a/BFBMX.Desktop/MainWindow.xaml
+++ b/BFBMX.Desktop/MainWindow.xaml
@@ -11,21 +11,25 @@
     
     <Grid Background="Azure">
         <Grid.RowDefinitions>
+            <!-- grid row 0 -->
             <RowDefinition Height="2"/>
             <RowDefinition Height="36"/>
             <RowDefinition Height="2"/>
             <RowDefinition Height="32"/>
-            <RowDefinition Height="8"/>
+            <RowDefinition Height="8"/> 
+            <!-- grid row 5 -->
             <RowDefinition Height="36"/>
             <RowDefinition Height="2"/>
             <RowDefinition Height="32"/>
             <RowDefinition Height="8"/>
-            <RowDefinition Height="36"/>
+            <RowDefinition Height="36"/> 
+            <!-- grid row 10 -->
             <RowDefinition Height="2"/>
             <RowDefinition Height="32"/>
             <RowDefinition Height="8"/>
-            <RowDefinition Height="36"/>
-            <RowDefinition Height="4"/>
+            <RowDefinition Height="72"/>
+            <RowDefinition Height="4"/> 
+            <!-- grid row 15-->
             <RowDefinition Height="160"/>
             <RowDefinition Height="8"/>
         </Grid.RowDefinitions>
@@ -193,29 +197,38 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Center"
                     Grid.Row="13"
                     Grid.Column="1"
                     Background="LightBlue">
-            <Label HorizontalAlignment="Left"
-                   Margin="2,4"
-                   Content="Logfile Path:"/>
-            <TextBlock IsEnabled="False"
+            
+            <StackPanel Orientation="Vertical"
+                        Margin="6,0">
+                <Label HorizontalAlignment="Center"
+                   Margin="6,4"
+                   Content="Click Logfile Path To Open In Explorer"/>
+                <Button Height="24"
+                    Padding="6,2,6,2"
+                    Margin="2"
+                    VerticalAlignment="Center"
+                    Background="Azure"
+                    Command="{Binding LaunchLogfilePathCommand}"
+                    Content="{Binding LogfilePath}" />
+            </StackPanel>
+            
+            <StackPanel Orientation="Vertical"
+                        Margin="6,0">
+                <Label HorizontalAlignment="Center"
+                   Margin="6,4"
+                   Content="Server Name and Port"/>
+                <TextBlock IsEnabled="False"
                        Height="24"
-                       Padding="6,2,6,2"
-                       Margin="2"
-                       VerticalAlignment="Center"
-                       Background="Azure"
-                       Text="{Binding LogfilePath}" />
-            <Label HorizontalAlignment="Left"
-                   Margin="2,4"
-                   Content="Server, Port:"/>
-            <TextBlock IsEnabled="False"
-                       Height="24"
-                       Padding="6,2,6,2"
+                       Padding="6,4,6,0"
                        Margin="2"
                        VerticalAlignment="Center"
                        Background="Azure"
                        Text="{Binding ServerNamePort}" />
+            </StackPanel>
         </StackPanel>
 
         <StackPanel Orientation="Vertical"

--- a/BFBMX.Desktop/Properties/PublishProfiles/ClickOnceProfile.pubxml
+++ b/BFBMX.Desktop/Properties/PublishProfiles/ClickOnceProfile.pubxml
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.0</ApplicationVersion>
+    <BootstrapperEnabled>True</BootstrapperEnabled>
+    <Configuration>Release</Configuration>
+    <CreateWebPageOnPublish>False</CreateWebPageOnPublish>
+    <GenerateManifests>true</GenerateManifests>
+    <Install>True</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <IsRevisionIncremented>False</IsRevisionIncremented>
+    <IsWebBootstrapper>False</IsWebBootstrapper>
+    <ManifestCertificateThumbprint>37AEAA6EC2B6ED9A2D7F8B07861045F5006B0109</ManifestCertificateThumbprint>
+    <ManifestKeyFile>BFBMX.Desktop_TemporaryKey.pfx</ManifestKeyFile>
+    <MapFileExtensions>True</MapFileExtensions>
+    <OpenBrowserOnPublish>False</OpenBrowserOnPublish>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0-windows\app.publish\</PublishDir>
+    <PublishUrl>C:\Users\ricoc\OneDrive\Bigfoot BMX Project\Release Builds\28-Apr-2024\Desktop\</PublishUrl>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishSingleFile>False</PublishSingleFile>
+    <SelfContained>False</SelfContained>
+    <SignatureAlgorithm>sha256RSA</SignatureAlgorithm>
+    <SignManifests>True</SignManifests>
+    <SkipPublishVerification>false</SkipPublishVerification>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UpdateEnabled>False</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateRequired>False</UpdateRequired>
+    <WebPageFileName>Publish.html</WebPageFileName>
+  </PropertyGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.NetCore.DesktopRuntime.6.0.x64">
+      <Install>true</Install>
+      <ProductName>.NET Desktop Runtime 6.0.29 (x64)</ProductName>
+    </BootstrapperPackage>
+  </ItemGroup>
+</Project>

--- a/BFBMX.Desktop/Properties/PublishProfiles/ClickOnceProfile1.pubxml
+++ b/BFBMX.Desktop/Properties/PublishProfiles/ClickOnceProfile1.pubxml
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.0</ApplicationVersion>
+    <BootstrapperEnabled>True</BootstrapperEnabled>
+    <Configuration>Release</Configuration>
+    <CreateWebPageOnPublish>False</CreateWebPageOnPublish>
+    <GenerateManifests>true</GenerateManifests>
+    <Install>True</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <IsRevisionIncremented>False</IsRevisionIncremented>
+    <IsWebBootstrapper>False</IsWebBootstrapper>
+    <ManifestCertificateThumbprint>018483A0A8ADF8B7D516B51CC575939B83FA6F6B</ManifestCertificateThumbprint>
+    <MapFileExtensions>True</MapFileExtensions>
+    <OpenBrowserOnPublish>False</OpenBrowserOnPublish>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0-windows\app.publish\</PublishDir>
+    <PublishUrl>C:\Users\ricoc\OneDrive\Bigfoot BMX Project\Release Builds\Desktop\</PublishUrl>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishSingleFile>False</PublishSingleFile>
+    <SelfContained>False</SelfContained>
+    <SignatureAlgorithm>sha256RSA</SignatureAlgorithm>
+    <SignManifests>True</SignManifests>
+    <SkipPublishVerification>false</SkipPublishVerification>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UpdateEnabled>False</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateRequired>False</UpdateRequired>
+    <WebPageFileName>Publish.html</WebPageFileName>
+  </PropertyGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.NetCore.DesktopRuntime.6.0.x64">
+      <Install>True</Install>
+      <ProductName>.NET Desktop Runtime 6.0.29 (x64)</ProductName>
+    </BootstrapperPackage>
+  </ItemGroup>
+</Project>

--- a/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/BFBMX.Desktop/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 
 namespace BFBMX.Desktop.ViewModels
@@ -34,22 +35,45 @@ namespace BFBMX.Desktop.ViewModels
             ServerNamePort = DesktopEnvFactory.GetServerHostnameAndPort();
         }
 
+        /***** Global UI Properties *****/
+
         [ObservableProperty]
         public string? _logfilePath;
         [ObservableProperty]
         public string? _serverNamePort;
-
         [ObservableProperty]
         public string? _alphaStatusMessage;
         [ObservableProperty]
         public string? _bravoStatusMessage;
         [ObservableProperty]
         public string? _charlieStatusMessage;
-
         [ObservableProperty]
         public ObservableCollection<DiscoveredFileModel> _mostRecentItems;
 
-        /***** Global Monitor Functions *****/
+        /// <summary>
+        /// Launches the log file path in Windows Explorer.
+        /// </summary>
+        /// <remarks>
+        /// This method opens the log file path in Windows Explorer using the default file explorer application.
+        /// </remarks>
+        /// <seealso cref="CanLaunchLogfilePath"/>
+        [RelayCommand(CanExecute = nameof(CanLaunchLogfilePath))]
+        public void LaunchLogfilePath()
+        {
+#pragma warning disable CS8604 // Possible null reference argument.
+            Process.Start("explorer.exe", LogfilePath);
+#pragma warning restore CS8604 // Possible null reference argument.
+        }
+
+
+        /// <summary>
+        /// Determines whether the log file path is valid and can be launched.
+        /// </summary>
+        /// <returns>True if the log file path is valid; otherwise, false.</returns>
+        public bool CanLaunchLogfilePath()
+        {
+            return IsGoodPath(LogfilePath);
+        }
 
         /// <summary>
         /// Event Handler for all three FileSystemWatcher calls when a file created event occurs.
@@ -225,7 +249,7 @@ namespace BFBMX.Desktop.ViewModels
             {
                 _alphaMonitor.EnableRaisingEvents = false;
                 _alphaMonitor.MonitoredPath = AlphaMonitorPath!;
-            } 
+            }
 
             try
             {
@@ -235,15 +259,15 @@ namespace BFBMX.Desktop.ViewModels
                 AlphaMonitorPathEnabled = false;
                 string isOrNotInitialized = AlphaMonitorInitialized ? "successfully" : "not";
                 SetStatusMessage(AlphaMonitorName, "Monitor initialized. Click Start to begin monitoring.");
-                _logger.LogInformation("Alpha Monitor {isOrNotInit} initialized for path: {monitorPath}", 
-                    isOrNotInitialized, 
+                _logger.LogInformation("Alpha Monitor {isOrNotInit} initialized for path: {monitorPath}",
+                    isOrNotInitialized,
                     AlphaMonitorPath);
             }
             catch (Exception ex)
             {
                 SetStatusMessage(AlphaMonitorName, "Unable to initialize! Click Destroy, add the path, then click Initialize.");
                 _logger.LogInformation("Alpha Monitor unable to initialize for {monitorPath}, exception msg: {exceptionMsg}",
-                                      AlphaMonitorPath, 
+                                      AlphaMonitorPath,
                                       ex.Message);
                 AlphaMonitorPathEnabled = true;
 
@@ -567,7 +591,7 @@ namespace BFBMX.Desktop.ViewModels
         public void DestroyBravoMonitor()
         {
             _logger.LogInformation("DestroyBravoMonitor: Button pressed.");
-            if(_bravoMonitor is not null)
+            if (_bravoMonitor is not null)
             {
                 _bravoMonitor.EnableRaisingEvents = false;
                 _bravoMonitor.Dispose();

--- a/BFBMX.ServerApi/.config/dotnet-tools.json
+++ b/BFBMX.ServerApi/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "8.0.4",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/BFBMX.ServerApi/Properties/PublishProfiles/FolderProfile1.pubxml
+++ b/BFBMX.ServerApi/Properties/PublishProfiles/FolderProfile1.pubxml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <DeleteExistingFiles>false</DeleteExistingFiles>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>C:\Users\ricoc\OneDrive\Bigfoot BMX Project\Release Builds\16-Apr-2024\Server</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <_TargetId>Folder</_TargetId>
+  </PropertyGroup>
+</Project>

--- a/BFBMX.ServerApi/Properties/PublishProfiles/FolderProfile2.pubxml
+++ b/BFBMX.ServerApi/Properties/PublishProfiles/FolderProfile2.pubxml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <DeleteExistingFiles>true</DeleteExistingFiles>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>C:\Users\ricoc\OneDrive\Bigfoot BMX Project\Release Builds\Server</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <_TargetId>Folder</_TargetId>
+    <SiteUrlToLaunchAfterPublish />
+    <TargetFramework>net6.0</TargetFramework>
+    <ProjectGuid>cad87f06-9147-4c75-b240-fb579f781cd5</ProjectGuid>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/BFBMX.ServerApi/Properties/PublishProfiles/FolderProfile3.pubxml
+++ b/BFBMX.ServerApi/Properties/PublishProfiles/FolderProfile3.pubxml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <DeleteExistingFiles>true</DeleteExistingFiles>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>C:\Users\ricoc\OneDrive\Bigfoot BMX Project\Release Builds\Server</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <_TargetId>Folder</_TargetId>
+    <SiteUrlToLaunchAfterPublish />
+    <TargetFramework>net6.0</TargetFramework>
+    <ProjectGuid>cad87f06-9147-4c75-b240-fb579f781cd5</ProjectGuid>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Each BFBMX Desktop component discovers Bib Records received via Winlink Express 
 
 ## Project Status
 
+7-May-2024:
+
+- Added button to open logile in Explorer from Desktop UI.
+
 6-May-2024:
 
 - Added day and timestamp to Monitor Status Messages.
@@ -272,7 +276,7 @@ _Note_: The primary purpose of the `Reset` button is to clear all memory of the 
 
 The Desktop App displays the location of its log files as configured using [Environment Variables](#configure-environment-variables).
 
-Two logs are maintained here:
+Click on the location to open the directory in Windows Explorer, where you will see two logfiles appear as files are detected by the Desktop App:
 
 - BFBMX Desktop App Log.
 - Captured Bib Records log.


### PR DESCRIPTION
- [x] Implement launching Windows Explorer to the path where Desktop App writes its logfiles.
- [x] Ensure Explorer is not tied to BF-BMX by launching it on a separate thread.
- [x] Update UI to inform the user they can click the PATH text to open Windows Explorer.
- [x] Implement UI changes with Accessibility in mind.
- [x] Update README.
